### PR TITLE
📦 feat(contract): add hello word function to contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [
   "contracts/course/course_registry",
   "contracts/course/course_access"
-]
+, "contracts/test_contract"]
 
 [workspace.dependencies]
 soroban-sdk = "22"

--- a/contracts/course/course_registry/src/lib.rs
+++ b/contracts/course/course_registry/src/lib.rs
@@ -46,4 +46,8 @@ impl CourseRegistry {
         functions::delete_course::course_registry_delete_course(&env, course_id)
             .unwrap_or_else(|e| panic!("{}", e))
     }
+
+    pub fn hello_world(_env: Env) -> String {
+        String::from_str(&_env, "Hello from Web3 👋")
+    }
 }

--- a/contracts/test_contract/Cargo.toml
+++ b/contracts/test_contract/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "test_contract"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+
+[profile.release]
+codegen-units = 1
+lto = true
+panic = "abort"
+strip = "symbols"
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/test_contract/src/lib.rs
+++ b/contracts/test_contract/src/lib.rs
@@ -1,0 +1,25 @@
+use soroban_sdk::{Env, String, contract, contractimpl};
+
+#[contract]
+pub struct TestContract;
+
+#[contractimpl]
+impl TestContract {
+    pub fn hello_world(_env: Env) -> String {
+        String::from_str(&_env, "Hello from Web3 👋")
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn test_hello() {
+        let env = Env::default();
+        let result = HelloContract::hello(env, "Immanuel");
+        assert_eq!(result, "Hello, Immanuel!");
+    }
+}


### PR DESCRIPTION
- Added ```hello_world``` function to contract, for frontend implementation. 
- The function returns Hello world for test 
  ```  pub fn hello_world(_env: Env) -> String {
        String::from_str(&_env, "Hello from Web3 👋")
    }```
- This PR closes the issue on https://github.com/SkillCert/skillcert_contracts/issues/26