### PR TITLE
Create contract to add goal to course

### DIFF
--- a/contracts/course/course_registry/src/lib.rs
+++ b/contracts/course/course_registry/src/lib.rs
@@ -54,4 +54,7 @@ impl CourseRegistry {
     pub fn hello_world(_env: Env) -> String {
         String::from_str(&_env, "Hello from Web3 👋")
     }
+    pub fn add_goal(env: Env, course_id: String, content: String) -> CourseGoal {
+    functions::add_goal::course_registry_add_goal(env, course_id, content)
+}
 }

--- a/contracts/course/course_registry/src/schema.rs
+++ b/contracts/course/course_registry/src/schema.rs
@@ -12,6 +12,24 @@ pub struct CourseModule {
     pub created_at: u64,
 }
 
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CourseGoal {
+    pub course_id: String,
+    pub content: String,
+    pub created_by: Address,
+    pub created_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum DataKey {
+    Module(String),
+    Courses,
+    CourseGoal(String), 
+}
+
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub enum DataKey {


### PR DESCRIPTION
## 🛠 Feature: Add Goal to Course 

### ✅ Summary
This PR adds support for defining learning goals (objectives) associated with a specific course.

### 🎯 Changes
- Added `CourseGoal` struct to schema
- Implemented `add_goal` function in contract:
  - Accepts `course_id` and `content`
  - Validates input
  - Checks that invoker is the course creator
  - Saves goal in persistent storage
  - Emits `goal_added` event
- Included basic unit test for adding goals

### 📦 Affected Files
- `schema.rs`
- `functions/add_goal.rs` (new)
- `lib.rs` (contract entry point)

### 📸 Preview / Test Evidence
- `test_add_goal_success` confirms goal is created and stored
- Event `goal_added` is emitted with goal content

### 📌 Notes
- Only course creators can add goals (no admin role yet)
- Goals are stored as a `Vec<CourseGoal>` per course

---

Let me know if you'd like to add support for editing/removing goals.

closes #38 
