### PR TITLE
Create the strucr for prerequisite and the remove function

### DIFF
--- a/contracts/course/course_registry/src/functions/remove_prerequisite.rs
+++ b/contracts/course/course_registry/src/functions/remove_prerequisite.rs
@@ -1,0 +1,49 @@
+use soroban_sdk::{Env, Address, String, Vec, symbol_short, Symbol};
+use crate::schema::{Course, DataKey};
+
+const PREREQ_REMOVED_EVENT: Symbol = symbol_short!("prereq_removed");
+
+pub fn course_registry_remove_prerequisite(
+    env: Env,
+    course_id: String,
+    prerequisite_course_id: String,
+) {
+    let invoker = env.invoker();
+
+    // Load course
+    let course_key = (symbol_short!("course"), course_id.clone());
+    let course: Course = env.storage().persistent()
+        .get(&course_key)
+        .expect("Course not found");
+
+    // Authorization: only creator can remove prerequisites
+    if course.creator != invoker {
+        panic!("Only the course creator can remove prerequisites");
+    }
+
+    // Load current list of prerequisites
+    let mut prerequisites: Vec<String> = env.storage().persistent()
+        .get(&DataKey::CoursePrerequisites(course_id.clone()))
+        .unwrap_or(Vec::new(&env));
+
+    // Find and remove the prerequisite
+    let index = prerequisites.iter().position(|id| id == &prerequisite_course_id);
+
+    match index {
+        Some(i) => {
+            prerequisites.remove(i);
+        },
+        None => {
+            panic!("Prerequisite not found in the list");
+        }
+    }
+
+    // Save updated prerequisites
+    env.storage().persistent().set(&DataKey::CoursePrerequisites(course_id.clone()), &prerequisites);
+
+    // Emit event
+    env.events().publish(
+        (PREREQ_REMOVED_EVENT, course_id),
+        prerequisite_course_id,
+    );
+}

--- a/contracts/course/course_registry/src/lib.rs
+++ b/contracts/course/course_registry/src/lib.rs
@@ -54,4 +54,9 @@ impl CourseRegistry {
     pub fn hello_world(_env: Env) -> String {
         String::from_str(&_env, "Hello from Web3 👋")
     }
+
+    pub fn remove_prerequisite(env: Env, course_id: String, prerequisite_course_id: String) {
+    functions::remove_prerequisite::course_registry_remove_prerequisite(env, course_id, prerequisite_course_id)
+}
+
 }

--- a/contracts/course/course_registry/src/schema.rs
+++ b/contracts/course/course_registry/src/schema.rs
@@ -15,6 +15,13 @@ pub struct CourseModule {
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub enum DataKey {
+    ...
+    CoursePrerequisites(String), // Key: course_id → Vec<String>
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum DataKey {
     Module(String), // This would represent the ("module", module_id) key
     Courses, // If courses are stored as a single map
 }


### PR DESCRIPTION
## 🚀 Feature: Remove Prerequisite from Course 

Closes #35 

### ✨ What’s New
- Added support for removing a specific prerequisite from a course.
- Validates that:
  - The course exists.
  - The prerequisite exists in the list.
  - The caller is the course creator.
- Updates storage and emits a `prereq_removed` event.

### 🧪 How to Test
- Call `remove_prerequisite(course_id, prerequisite_course_id)`
- Confirm that:
  - The prerequisite is removed from storage.
  - An event is emitted.
  - Unauthorized users cannot perform the action.

### 🔒 Permissions
- Only course creators (future: admins) can remove prerequisites.

---

Let me know if you want me to implement the inverse function (`add_prerequisite`) as a follow-up.
