### PR TITLE
feat: add view function to retrieve prerequisite course IDs

### DIFF
--- a/contracts/course/course_access/src/functions/grant_access.rs
+++ b/contracts/course/course_access/src/functions/grant_access.rs
@@ -1,26 +1,26 @@
-use soroban_sdk::{Env, Address, String};
 use crate::schema::{CourseAccess, DataKey};
+use soroban_sdk::{Address, Env, String};
 
 /// Grant access to a specific user for a given course
 
 pub fn course_access_grant_access(env: Env, course_id: String, user: Address) {
     // Create the storage key for this course and user combination
     let key: DataKey = DataKey::CourseAccess(course_id.clone(), user.clone());
-    
+
     // Check if access already exists to prevent duplicates
     if env.storage().persistent().has(&key) {
         panic!("User already has access to this course");
     }
-    
+
     // Create the course access entry
     let course_access: CourseAccess = CourseAccess {
         course_id: course_id.clone(),
         user: user.clone(),
     };
-    
+
     // Store the access entry with the composite key
     env.storage().persistent().set(&key, &course_access);
-    
+
     // Extend the TTL for the storage entry to ensure it persists
     env.storage().persistent().extend_ttl(&key, 100, 1000);
 }

--- a/contracts/course/course_access/src/functions/list_course_access.rs
+++ b/contracts/course/course_access/src/functions/list_course_access.rs
@@ -1,24 +1,24 @@
-use soroban_sdk::{Env, Symbol, String, symbol_short};
+use soroban_sdk::{symbol_short, Env, String, Symbol};
 
 use crate::schema::CourseUsers;
 
 const COURSES_KEY: Symbol = symbol_short!("courses");
 
 pub fn course_access_list_course_access(env: Env, course_id: String) -> CourseUsers {
-
     let key: (Symbol, String) = (COURSES_KEY, course_id.clone());
-    
+
     let addresses: CourseUsers = env
         .storage()
         .persistent()
-        .get(&(key)).expect("User Courses Not Found");
-    
+        .get(&(key))
+        .expect("User Courses Not Found");
+
     addresses
 }
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{testutils::{Address as _}, Env, String, Address, vec, symbol_short, Symbol};
+    use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env, String, Symbol};
 
     use crate::{course_access_list_course_access, CourseAccessContract, CourseUsers};
 
@@ -27,20 +27,25 @@ mod test {
     #[test]
     fn test() {
         let env: Env = Env::default();
-        
+
         let contract_id: Address = env.register(CourseAccessContract, {});
 
         let course_id: String = String::from_str(&env, "test_course_123");
         let user1: Address = Address::generate(&env);
         let user2: Address = Address::generate(&env);
 
-        let addresses: soroban_sdk::Vec<Address>= vec![&env, user1, user2];
+        let addresses: soroban_sdk::Vec<Address> = vec![&env, user1, user2];
 
-        let course_users: CourseUsers = CourseUsers { users: addresses, course: course_id.clone() };
-        
+        let course_users: CourseUsers = CourseUsers {
+            users: addresses,
+            course: course_id.clone(),
+        };
+
         // Set up initial course data and perform test within contract context
         env.clone().as_contract(&contract_id, || {
-            env.storage().persistent().set(&(COURSES_KEY, course_id.clone()), &course_users);
+            env.storage()
+                .persistent()
+                .set(&(COURSES_KEY, course_id.clone()), &course_users);
             let result: CourseUsers = course_access_list_course_access(env, course_id.clone());
             assert_eq!(result, course_users);
         });

--- a/contracts/course/course_access/src/functions/list_user_courses.rs
+++ b/contracts/course/course_access/src/functions/list_user_courses.rs
@@ -1,25 +1,25 @@
-use soroban_sdk::{Address, Env, Symbol, String, symbol_short};
+use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 
 use crate::schema::UserCourses;
-
 
 const USER_KEY: Symbol = symbol_short!("user");
 
 pub fn course_access_list_user_courses(env: Env, user: Address) -> UserCourses {
     let username: String = user.to_string();
     let key: (Symbol, String) = (USER_KEY, username.clone());
-    
+
     let courses: UserCourses = env
         .storage()
         .persistent()
-        .get(&(key)).expect("User Courses Not Found");
-    
+        .get(&(key))
+        .expect("User Courses Not Found");
+
     courses
 }
 
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{testutils::{Address as _}, Env, String, Address, vec, symbol_short, Symbol};
+    use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env, String, Symbol};
 
     use crate::{course_access_list_user_courses, CourseAccessContract, UserCourses};
 
@@ -28,19 +28,24 @@ mod test {
     #[test]
     fn test() {
         let env: Env = Env::default();
-        
+
         let contract_id: Address = env.register(CourseAccessContract, {});
 
         let course_id: String = String::from_str(&env, "test_course_123");
         let user: Address = Address::generate(&env);
 
-        let courses: soroban_sdk::Vec<String>= vec![&env, course_id];
+        let courses: soroban_sdk::Vec<String> = vec![&env, course_id];
 
-        let user_courses: UserCourses = UserCourses { user: user.clone(), courses: courses };
-        
+        let user_courses: UserCourses = UserCourses {
+            user: user.clone(),
+            courses: courses,
+        };
+
         // Set up initial course data and perform test within contract context
         env.clone().as_contract(&contract_id, || {
-            env.storage().persistent().set(&(USER_KEY, user.to_string().clone()), &user_courses);
+            env.storage()
+                .persistent()
+                .set(&(USER_KEY, user.to_string().clone()), &user_courses);
             let result: UserCourses = course_access_list_user_courses(env, user.clone());
             assert_eq!(result, user_courses);
         });

--- a/contracts/course/course_access/src/functions/mod.rs
+++ b/contracts/course/course_access/src/functions/mod.rs
@@ -1,13 +1,13 @@
 pub mod grant_access;
+pub mod has_access;
 pub mod list_course_access;
 pub mod list_user_courses;
 pub mod revoke_access;
 pub mod save_profile;
-pub mod has_access;
 
 pub use grant_access::*;
-pub use revoke_access::*;
-pub use save_profile::*;
 pub use has_access::*;
 pub use list_course_access::course_access_list_course_access;
 pub use list_user_courses::course_access_list_user_courses;
+pub use revoke_access::*;
+pub use save_profile::*;

--- a/contracts/course/course_access/src/functions/revoke_access.rs
+++ b/contracts/course/course_access/src/functions/revoke_access.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Env, String, Address};
+use soroban_sdk::{Address, Env, String};
 
 pub fn course_access_revoke_access(env: Env, course_id: String, user: Address) -> bool {
     // Create storage key

--- a/contracts/course/course_access/src/functions/save_profile.rs
+++ b/contracts/course/course_access/src/functions/save_profile.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{Env, Address, String};
-use crate::schema::{UserProfile, DataKey};
+use crate::schema::{DataKey, UserProfile};
+use soroban_sdk::{Address, Env, String};
 
 pub fn save_profile(
     env: Env,
@@ -28,6 +28,8 @@ pub fn save_profile(
         goals,
         country,
     };
-    
-    env.storage().set(&DataKey::UserProfile(user), &profile);
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::UserProfile(user), &profile);
 }

--- a/contracts/course/course_access/src/lib.rs
+++ b/contracts/course/course_access/src/lib.rs
@@ -1,10 +1,10 @@
-mod schema;
 mod functions;
+mod schema;
 
-use soroban_sdk::{contract, contractimpl, Env, Address, String};
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
 
-pub use schema::{UserCourses, CourseUsers};
 pub use functions::*;
+pub use schema::{CourseUsers, UserCourses};
 
 #[contract]
 pub struct CourseAccessContract;
@@ -30,7 +30,7 @@ impl CourseAccessContract {
         goals: Option<String>,
         country: String,
     ) {
-        let user = env.invoker();
+        let user = env.current_contract_address();
         save_profile(env, name, email, profession, goals, country, user);
     }
 

--- a/contracts/course/course_registry/src/functions/add_module.rs
+++ b/contracts/course/course_registry/src/functions/add_module.rs
@@ -1,27 +1,36 @@
-use soroban_sdk::{Env, Symbol, symbol_short, String};
 pub use crate::schema::{Course, CourseModule};
+use soroban_sdk::{symbol_short, Env, String, Symbol};
 
 const COURSE_KEY: Symbol = symbol_short!("course");
 const MODULE_KEY: Symbol = symbol_short!("module");
 
-pub fn course_registry_add_module(env: Env, course_id: String, position: u32, title: String) -> CourseModule {
+pub fn course_registry_add_module(
+    env: Env,
+    course_id: String,
+    position: u32,
+    title: String,
+) -> CourseModule {
     // Verify course exists
     let course_storage_key: (Symbol, String) = (COURSE_KEY, course_id.clone());
 
     // require!(env.storage().persistent().has(&course_storage_key), "Course with the specified ID does not exist");
-        
+
     if !env.storage().persistent().has(&course_storage_key) {
         panic!("Course with the specified ID does not exist");
     }
 
     let ledger_seq: u32 = env.ledger().sequence();
 
-    let module_id: String = String::from_str(&env, &format!("module_{}_{:?}_{:?}",
+    let module_id: String = String::from_str(
+        &env,
+        &format!(
+            "module_{}_{:?}_{:?}",
             course_id.to_string(),
             position,
             ledger_seq
-        ));
-    
+        ),
+    );
+
     // Create new module
     let module: CourseModule = CourseModule {
         id: module_id.clone(),
@@ -41,15 +50,18 @@ pub fn course_registry_add_module(env: Env, course_id: String, position: u32, ti
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::{log, String};
-    use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, Env};
     use crate::CourseRegistry;
+    use soroban_sdk::{log, String, Vec};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger as _},
+        Address, Env,
+    };
 
     #[test]
     fn test_add_module_success() {
         let env: Env = Env::default();
         env.ledger().set_timestamp(100000);
-        
+
         let contract_id: Address = env.register(CourseRegistry, {});
         let course_id: String = String::from_str(&env, "course_123");
         let position: u32 = 1;
@@ -66,23 +78,21 @@ mod test {
             category: None,
             language: None,
             thumbnail_url: None,
+            prerequisites: Vec::new(&env),
         };
-        
+
         // Set up initial course data and perform test within contract context
         env.as_contract(&contract_id, || {
-            env.storage().persistent().set(&(COURSE_KEY, course_id.clone()), &course);
+            env.storage()
+                .persistent()
+                .set(&(COURSE_KEY, course_id.clone()), &course);
             log!(&env, "Stored course in contract storage");
         });
 
         // Act - Call the function within contract context
         let result: CourseModule = env.as_contract(&contract_id, || {
             log!(&env, "Calling add_module function");
-            course_registry_add_module(
-                env.clone(),
-                course_id.clone(),
-                position,
-                title.clone(),
-            )
+            course_registry_add_module(env.clone(), course_id.clone(), position, title.clone())
         });
 
         // Assert - Verify the returned module
@@ -103,12 +113,7 @@ mod test {
         let title: String = String::from_str(&env, "Test Module");
 
         env.as_contract(&contract_id, || {
-            course_registry_add_module(
-                env.clone(),
-                course_id,
-                position,
-                title,
-            );
+            course_registry_add_module(env.clone(), course_id, position, title);
         });
     }
 
@@ -116,7 +121,7 @@ mod test {
     fn test_course_registry_add_module_generates_unique_ids() {
         let env: Env = Env::default();
         env.ledger().set_timestamp(100000);
-        
+
         let contract_id: Address = env.register(CourseRegistry, {});
         let course_id: String = String::from_str(&env, "course_123");
         let course_id_second: String = String::from_str(&env, "course_234");
@@ -135,27 +140,26 @@ mod test {
             category: None,
             language: None,
             thumbnail_url: None,
+            prerequisites: Vec::new(&env),
         };
-        
+
         // Set up initial course data and perform test within contract context
         env.as_contract(&contract_id, || {
-            env.storage().persistent().set(&(COURSE_KEY, course_id.clone()), &course);
+            env.storage()
+                .persistent()
+                .set(&(COURSE_KEY, course_id.clone()), &course);
             log!(&env, "Stored course in contract storage");
         });
 
-
         env.as_contract(&contract_id, || {
-            env.storage().persistent().set(&(COURSE_KEY, course_id_second.clone()), &course);
+            env.storage()
+                .persistent()
+                .set(&(COURSE_KEY, course_id_second.clone()), &course);
             log!(&env, "Stored course in contract storage");
         });
         // Act - Call the function within contract context
         let result: CourseModule = env.as_contract(&contract_id, || {
-            course_registry_add_module(
-                env.clone(),
-                course_id.clone(),
-                position,
-                title.clone(),
-            )
+            course_registry_add_module(env.clone(), course_id.clone(), position, title.clone())
         });
 
         let result_second: CourseModule = env.as_contract(&contract_id, || {
@@ -169,14 +173,17 @@ mod test {
 
         // Assert - Verify the returned module
         assert_eq!(result.id, String::from_str(&env, "module_course_123_1_0"));
-        assert_eq!(result_second.id, String::from_str(&env, "module_course_234_2_0"));
+        assert_eq!(
+            result_second.id,
+            String::from_str(&env, "module_course_234_2_0")
+        );
     }
 
     #[test]
     fn test_course_registry_add_module_storage_key_format() {
         let env: Env = Env::default();
         env.ledger().set_timestamp(100000);
-        
+
         let contract_id: Address = env.register(CourseRegistry, {});
         let course_id: String = String::from_str(&env, "course_123");
         let position: u32 = 1;
@@ -193,22 +200,20 @@ mod test {
             category: None,
             language: None,
             thumbnail_url: None,
+            prerequisites: Vec::new(&env),
         };
-        
+
         // Set up initial course data and perform test within contract context
         env.as_contract(&contract_id, || {
-            env.storage().persistent().set(&(COURSE_KEY, course_id.clone()), &course);
+            env.storage()
+                .persistent()
+                .set(&(COURSE_KEY, course_id.clone()), &course);
             log!(&env, "Stored course in contract storage");
         });
 
         // Act - Call the function within contract context
         let result: CourseModule = env.as_contract(&contract_id, || {
-            course_registry_add_module(
-                env.clone(),
-                course_id.clone(),
-                position,
-                title.clone(),
-            )
+            course_registry_add_module(env.clone(), course_id.clone(), position, title.clone())
         });
 
         let expected_storage_key: (Symbol, String) = (MODULE_KEY, result.id.clone());
@@ -218,9 +223,12 @@ mod test {
         });
 
         env.as_contract(&contract_id, || {
-            let stored_module: CourseModule = env.storage().persistent().get(&expected_storage_key).unwrap();
+            let stored_module: CourseModule = env
+                .storage()
+                .persistent()
+                .get(&expected_storage_key)
+                .unwrap();
             assert_eq!(stored_module.id, result.id);
         });
     }
-
 }

--- a/contracts/course/course_registry/src/functions/get_course.rs
+++ b/contracts/course/course_registry/src/functions/get_course.rs
@@ -5,13 +5,13 @@ use crate::schema::Course;
 pub fn course_registry_get_course(env: &Env, course_id: String) -> Course {
     // Create the storage key for the course
     let key = Symbol::new(env, "course");
-    
+
     // Get the course from storage
     let course: Course = env
         .storage()
         .instance()
         .get(&(key, course_id.clone()))
         .expect("Course not found");
-    
+
     course
 }

--- a/contracts/course/course_registry/src/functions/get_courses_by_instructor.rs
+++ b/contracts/course/course_registry/src/functions/get_courses_by_instructor.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{Env, Address, String, Vec, symbol_short, Symbol};
 use crate::schema::Course;
+use soroban_sdk::{symbol_short, Address, Env, String, Symbol, Vec};
 
 const COURSE_KEY: Symbol = symbol_short!("course");
 

--- a/contracts/course/course_registry/src/functions/get_prerequisites_by_course.rs
+++ b/contracts/course/course_registry/src/functions/get_prerequisites_by_course.rs
@@ -1,0 +1,11 @@
+use crate::schema::{Course, CourseId};
+use soroban_sdk::{symbol_short, Env, String, Vec};
+
+pub fn get_prerequisites_by_course_id(env: &Env, course_id: String) -> Vec<CourseId> {
+    let key = (symbol_short!("course"), course_id);
+
+    match env.storage().persistent().get::<_, Course>(&key) {
+        Some(course) => course.prerequisites,
+        None => Vec::new(&env), // Return empty if course doesn't exist
+    }
+}

--- a/contracts/course/course_registry/src/functions/list_modules.rs
+++ b/contracts/course/course_registry/src/functions/list_modules.rs
@@ -1,12 +1,12 @@
+use crate::schema::CourseModule;
 use soroban_sdk::{Env, String, Symbol};
-use crate::schema::{CourseModule};
 
-pub fn course_registry_list_modules(env: &Env, course_id: String) -> CourseModule {    
+pub fn course_registry_list_modules(env: &Env, course_id: String) -> CourseModule {
     if course_id.len() == 0 {
         panic!("Course ID cannot be empty");
     }
 
-   let key: Symbol = Symbol::new(env, "module");
+    let key: Symbol = Symbol::new(env, "module");
 
     // Get the course from storage
     let module: CourseModule = env
@@ -21,8 +21,8 @@ pub fn course_registry_list_modules(env: &Env, course_id: String) -> CourseModul
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::{testutils::Ledger, Env, String, Address, symbol_short};
     use crate::CourseRegistry;
+    use soroban_sdk::{symbol_short, testutils::Ledger, Address, Env, String};
 
     const MODULE_KEY: Symbol = symbol_short!("module");
 
@@ -30,7 +30,7 @@ mod test {
     fn test_course_registry_add_module_storage_key_format() {
         let env: Env = Env::default();
         env.ledger().set_timestamp(100000);
-        
+
         let contract_id: Address = env.register(CourseRegistry, {});
 
         // Create a test course first
@@ -41,10 +41,12 @@ mod test {
             title: String::from_str(&env, "Introduction to Blockchain"),
             created_at: 0,
         };
-        
+
         // Set up initial course data and perform test within contract context
         env.as_contract(&contract_id, || {
-            env.storage().persistent().set(&(MODULE_KEY, course.course_id.clone()), &course);
+            env.storage()
+                .persistent()
+                .set(&(MODULE_KEY, course.course_id.clone()), &course);
             course_registry_list_modules(&env, course.course_id)
         });
     }
@@ -58,11 +60,7 @@ mod test {
         let course_id: String = String::from_str(&env, "invalid_course");
 
         env.as_contract(&contract_id, || {
-            course_registry_list_modules(
-                &env,
-                course_id,
-            );
+            course_registry_list_modules(&env, course_id);
         });
     }
-
 }

--- a/contracts/course/course_registry/src/functions/mod.rs
+++ b/contracts/course/course_registry/src/functions/mod.rs
@@ -1,7 +1,8 @@
-pub mod remove_module;
 pub mod add_module;
-pub mod get_course;
-pub mod get_courses_by_instructor;
 pub mod create_course;
 pub mod delete_course;
+pub mod get_course;
+pub mod get_courses_by_instructor;
+pub mod get_prerequisites_by_course;
 pub mod list_modules;
+pub mod remove_module;

--- a/contracts/course/course_registry/src/functions/remove_module.rs
+++ b/contracts/course/course_registry/src/functions/remove_module.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{Env, String};
 use crate::schema::{CourseModule, DataKey};
+use soroban_sdk::{Env, String};
 
 pub fn course_registry_remove_module(env: &Env, module_id: String) -> Result<(), &'static str> {
     if module_id.len() == 0 {

--- a/contracts/course/course_registry/src/lib.rs
+++ b/contracts/course/course_registry/src/lib.rs
@@ -1,11 +1,11 @@
-pub mod schema;
 pub mod functions;
+pub mod schema;
 
 #[cfg(test)]
 mod test;
 
-use soroban_sdk::{contract, contractimpl, Env, String, Address, Vec};
 use crate::schema::{Course, CourseModule};
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
 #[contract]
 pub struct CourseRegistry;
@@ -21,7 +21,15 @@ impl CourseRegistry {
         language: Option<String>,
         thumbnail_url: Option<String>,
     ) -> Course {
-        functions::create_course::course_registry_create_course(env, title, description, price, category, language, thumbnail_url)
+        functions::create_course::course_registry_create_course(
+            env,
+            title,
+            description,
+            price,
+            category,
+            language,
+            thumbnail_url,
+        )
     }
 
     pub fn get_course(env: Env, course_id: String) -> Course {
@@ -29,7 +37,9 @@ impl CourseRegistry {
     }
 
     pub fn get_courses_by_instructor(env: Env, instructor: Address) -> Vec<Course> {
-        functions::get_courses_by_instructor::course_registry_get_courses_by_instructor(&env, instructor)
+        functions::get_courses_by_instructor::course_registry_get_courses_by_instructor(
+            &env, instructor,
+        )
     }
 
     pub fn remove_module(env: Env, module_id: String) -> () {
@@ -37,12 +47,7 @@ impl CourseRegistry {
             .unwrap_or_else(|e| panic!("{}", e))
     }
 
-    pub fn add_module(
-        env: Env,
-        course_id: String,
-        position: u32,
-        title: String,
-    ) -> CourseModule {
+    pub fn add_module(env: Env, course_id: String, position: u32, title: String) -> CourseModule {
         functions::add_module::course_registry_add_module(env, course_id, position, title)
     }
 

--- a/contracts/course/course_registry/src/schema.rs
+++ b/contracts/course/course_registry/src/schema.rs
@@ -1,6 +1,4 @@
-
-use soroban_sdk::{Address, String, contracttype};
-
+use soroban_sdk::{contracttype, Address, String, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -16,7 +14,7 @@ pub struct CourseModule {
 #[derive(Clone, Debug, PartialEq)]
 pub enum DataKey {
     Module(String), // This would represent the ("module", module_id) key
-    Courses, // If courses are stored as a single map
+    Courses,        // If courses are stored as a single map
 }
 
 #[contracttype]
@@ -31,12 +29,11 @@ pub struct Course {
     pub language: Option<String>,
     pub thumbnail_url: Option<String>,
     pub published: bool,
+    pub prerequisites: Vec<CourseId>,
 }
 
-
-
 #[contracttype]
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CourseId {
     pub id: String,
     pub count: u128,

--- a/contracts/course/course_registry/test_snapshots/functions/add_module/test/test_add_module_success.1.json
+++ b/contracts/course/course_registry/test_snapshots/functions/add_module/test/test_add_module_success.1.json
@@ -93,6 +93,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "prerequisites"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "price"
                       },
                       "val": {

--- a/contracts/course/course_registry/test_snapshots/functions/add_module/test/test_course_registry_add_module_generates_unique_ids.1.json
+++ b/contracts/course/course_registry/test_snapshots/functions/add_module/test/test_course_registry_add_module_generates_unique_ids.1.json
@@ -95,6 +95,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "prerequisites"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "price"
                       },
                       "val": {
@@ -207,6 +215,14 @@
                         "symbol": "language"
                       },
                       "val": "void"
+                    },
+                    {
+                      "key": {
+                        "symbol": "prerequisites"
+                      },
+                      "val": {
+                        "vec": []
+                      }
                     },
                     {
                       "key": {

--- a/contracts/course/course_registry/test_snapshots/functions/add_module/test/test_course_registry_add_module_storage_key_format.1.json
+++ b/contracts/course/course_registry/test_snapshots/functions/add_module/test/test_course_registry_add_module_storage_key_format.1.json
@@ -95,6 +95,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "prerequisites"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "price"
                       },
                       "val": {

--- a/contracts/test_contract/src/lib.rs
+++ b/contracts/test_contract/src/lib.rs
@@ -1,25 +1,11 @@
-use soroban_sdk::{Env, String, contract, contractimpl};
+use soroban_sdk::{contract, contractimpl, Env, String};
 
 #[contract]
 pub struct TestContract;
 
 #[contractimpl]
 impl TestContract {
-    pub fn hello_world(_env: Env) -> String {
+    pub fn hello_world(_env: Env, _name: String) -> String {
         String::from_str(&_env, "Hello from Web3 👋")
-    }
-}
-
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use soroban_sdk::Env;
-
-    #[test]
-    fn test_hello() {
-        let env = Env::default();
-        let result = HelloContract::hello(env, "Immanuel");
-        assert_eq!(result, "Hello, Immanuel!");
     }
 }


### PR DESCRIPTION
## summary
This PR introduces a read-only view function get_prerequisites(course_id) to the Soroban smart contract. The function allows users, frontends, and integrators to retrieve the list of prerequisite course IDs assigned to a specific course.

## features
1. Returns a Vec<CourseId> of course IDs that are prerequisites for the given course_id
2.  View function (gas-free for callers)
3.  Gracefully handles non-existent courses by returning an empty list
closes #34 