### PR TITLE
Resolve authorization errors and compiler warnings in Soroban contracts

### DIFF
--- a/contracts/course/course_access/src/functions/mod.rs
+++ b/contracts/course/course_access/src/functions/mod.rs
@@ -9,7 +9,6 @@ pub mod save_profile;
 pub mod transfer_course_access;
 
 pub use grant_access::*;
-pub use has_access::*;
 pub use list_course_access::course_access_list_course_access;
 pub use list_user_courses::course_access_list_user_courses;
 pub use revoke_access::*;

--- a/contracts/course/course_registry/src/functions/add_goal.rs
+++ b/contracts/course/course_registry/src/functions/add_goal.rs
@@ -1,6 +1,6 @@
 use crate::functions::utils;
 use crate::schema::{Course, CourseGoal, DataKey};
-use soroban_sdk::{symbol_short, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 
 const GOAL_ADDED_EVENT: Symbol = symbol_short!("goaladd");
 

--- a/contracts/course/course_registry/src/functions/edit_goal.rs
+++ b/contracts/course/course_registry/src/functions/edit_goal.rs
@@ -60,7 +60,7 @@ pub fn course_registry_edit_goal(
 mod test {
     use crate::schema::Course;
     use crate::{CourseRegistry, CourseRegistryClient};
-    use soroban_sdk::{testutils::{Address as _, Events}, Address, Env, String, Vec};
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
     fn setup_course_and_goal(env: &Env, client: &CourseRegistryClient, creator: &Address) -> (Course, String) {
 

--- a/contracts/course/course_registry/src/test.rs
+++ b/contracts/course/course_registry/src/test.rs
@@ -229,61 +229,59 @@ fn test_get_prerequisites_by_course_id() {
 #[test]
 fn test_list_categories_counts() {
     let env = Env::default();
+    env.mock_all_auths(); // ⭐ MOCK AUTH FUERA
+    
     let contract_id = env.register(CourseRegistry, ());
+    let client = CourseRegistryClient::new(&env, &contract_id);
     let creator = Address::generate(&env);
 
-    env.as_contract(&contract_id, || {
-        // Create 3 courses: 2 in "Programming", 1 in "Data"
-        CourseRegistry::create_course(
-            env.clone(),
-            creator.clone(),
-            String::from_str(&env, "A"),
-            String::from_str(&env, "d"),
-            10,
-            Some(String::from_str(&env, "Programming")),
-            None,
-            None,
-        );
-        CourseRegistry::create_course(
-            env.clone(),
-            creator.clone(),
-            String::from_str(&env, "B"),
-            String::from_str(&env, "d"),
-            10,
-            Some(String::from_str(&env, "Data")),
-            None,
-            None,
-        );
-        CourseRegistry::create_course(
-            env.clone(),
-            creator.clone(),
-            String::from_str(&env, "C"),
-            String::from_str(&env, "d"),
-            10,
-            Some(String::from_str(&env, "Programming")),
-            None,
-            None,
-        );
+    // ⭐ USAR CLIENT EN LUGAR DE LLAMADAS DIRECTAS
+    client.create_course(
+        &creator,
+        &String::from_str(&env, "A"),
+        &String::from_str(&env, "d"),
+        &10,
+        &Some(String::from_str(&env, "Programming")),
+        &None,
+        &None,
+    );
+    client.create_course(
+        &creator,
+        &String::from_str(&env, "B"),
+        &String::from_str(&env, "d"),
+        &10,
+        &Some(String::from_str(&env, "Data")),
+        &None,
+        &None,
+    );
+    client.create_course(
+        &creator,
+        &String::from_str(&env, "C"),
+        &String::from_str(&env, "d"),
+        &10,
+        &Some(String::from_str(&env, "Programming")),
+        &None,
+        &None,
+    );
 
-        // Call the function to list categories
-        let cats = course_registry_list_categories(&env);
-        assert_eq!(cats.len(), 2); // Should have 2 unique categories
+    // Call the function to list categories
+    let cats = client.list_categories();
+    assert_eq!(cats.len(), 2); // Should have 2 unique categories
 
-        // Verify counts without assuming order
-        let mut prog = 0u128;
-        let mut data = 0u128;
-        for c in cats.iter() {
-            let cname = c.name.clone();
-            if cname.to_string() == "Programming" {
-                prog = c.count;
-            }
-            if cname.to_string() == "Data" {
-                data = c.count;
-            }
+    // Verify counts without assuming order
+    let mut prog = 0u128;
+    let mut data = 0u128;
+    for c in cats.iter() {
+        let cname = c.name.clone();
+        if cname.to_string() == "Programming" {
+            prog = c.count;
         }
-        assert_eq!(prog, 2);
-        assert_eq!(data, 1);
-    });
+        if cname.to_string() == "Data" {
+            data = c.count;
+        }
+    }
+    assert_eq!(prog, 2);
+    assert_eq!(data, 1);
 }
 
 #[test]
@@ -298,90 +296,88 @@ fn test_list_categories_empty() {
 #[test]
 fn test_list_categories_ignores_none() {
     let env: Env = Env::default();
-    env.mock_all_auths();
-    let creator: Address = Address::generate(&env);
+    env.mock_all_auths(); // ⭐ MOCK AUTH FUERA
+    
     let contract_id: Address = env.register(CourseRegistry, ());
+    let client = CourseRegistryClient::new(&env, &contract_id);
+    let creator: Address = Address::generate(&env);
 
-    env.as_contract(&contract_id, || {
-        // Course with category (Some)
-        CourseRegistry::create_course(
-            env.clone(),
-            creator.clone(),
-            String::from_str(&env, "B"),
-            String::from_str(&env, "d"),
-            10,
-            Some(String::from_str(&env, "Programming")),
-            None,
-            None,
-        );
+    // ⭐ USAR CLIENT EN LUGAR DE LLAMADAS DIRECTAS
+    client.create_course(
+        &creator,
+        &String::from_str(&env, "B"),
+        &String::from_str(&env, "d"),
+        &10,
+        &Some(String::from_str(&env, "Programming")),
+        &None,
+        &None,
+    );
 
-        let cats = course_registry_list_categories(&env);
-        assert_eq!(cats.len(), 1); // Only "Programming" should be returned
-        let c = cats.get(0).unwrap();
-        assert_eq!(c.name, String::from_str(&env, "Programming"));
-        assert_eq!(c.count, 1);
-    });
+    let cats = client.list_categories();
+    assert_eq!(cats.len(), 1); // Only "Programming" should be returned
+    let c = cats.get(0).unwrap();
+    assert_eq!(c.name, String::from_str(&env, "Programming"));
+    assert_eq!(c.count, 1);
 }
 
 #[test]
 fn test_list_categories_with_id_gaps() {
     let env = Env::default();
+    env.mock_all_auths(); // ⭐ MOCK AUTH FUERA
+    
     let contract_id = env.register(CourseRegistry, ());
+    let client = CourseRegistryClient::new(&env, &contract_id);
     let creator = Address::generate(&env);
 
-    env.as_contract(&contract_id, || {
-        // Create course 1
-        CourseRegistry::create_course(
-            env.clone(),
-            creator.clone(),
-            String::from_str(&env, "Course 1"),
-            String::from_str(&env, "Desc"),
-            10,
-            Some(String::from_str(&env, "Programming")),
-            None,
-            None,
-        );
-        // Create course 2
-        CourseRegistry::create_course(
-            env.clone(),
-            creator.clone(),
-            String::from_str(&env, "Course 2"),
-            String::from_str(&env, "Desc"),
-            10,
-            Some(String::from_str(&env, "Data")),
-            None,
-            None,
-        );
+    // ⭐ USAR CLIENT EN LUGAR DE LLAMADAS DIRECTAS
+    client.create_course(
+        &creator,
+        &String::from_str(&env, "Course 1"),
+        &String::from_str(&env, "Desc"),
+        &10,
+        &Some(String::from_str(&env, "Programming")),
+        &None,
+        &None,
+    );
+    client.create_course(
+        &creator,
+        &String::from_str(&env, "Course 2"),
+        &String::from_str(&env, "Desc"),
+        &10,
+        &Some(String::from_str(&env, "Data")),
+        &None,
+        &None,
+    );
 
-        // Manually delete course 2 to create an ID gap
+    // Manually delete course 2 to create an ID gap
+    env.as_contract(&contract_id, || {
         let key = (symbol_short!("course"), String::from_str(&env, "2"));
         env.storage().persistent().remove(&key);
-
-        // Create course 3 (this will still have ID 3)
-        CourseRegistry::create_course(
-            env.clone(),
-            creator.clone(),
-            String::from_str(&env, "Course 3"),
-            String::from_str(&env, "Desc"),
-            10,
-            Some(String::from_str(&env, "Programming")),
-            None,
-            None,
-        );
-
-        // Call the function - it should skip missing ID 2 but still count 1 and 3
-        let cats = course_registry_list_categories(&env);
-        let mut prog = 0u128;
-        let mut data = 0u128;
-        for c in cats.iter() {
-            if c.name.to_string() == "Programming" {
-                prog = c.count;
-            }
-            if c.name.to_string() == "Data" {
-                data = c.count;
-            }
-        }
-        assert_eq!(prog, 2); // Course 1 and Course 3
-        assert_eq!(data, 0); // Course 2 was deleted
     });
+
+    // Create course 3 (this will still have ID 3)
+    client.create_course(
+        &creator,
+        &String::from_str(&env, "Course 3"),
+        &String::from_str(&env, "Desc"),
+        &10,
+        &Some(String::from_str(&env, "Programming")),
+        &None,
+        &None,
+    );
+
+    // Call the function - it should skip missing ID 2 but still count 1 and 3
+    let cats = client.list_categories();
+    let mut prog = 0u128;
+    let mut data = 0u128;
+    for c in cats.iter() {
+        if c.name.to_string() == "Programming" {
+            prog = c.count;
+        }
+        if c.name.to_string() == "Data" {
+            data = c.count;
+        }
+    }
+    assert_eq!(prog, 2); // Course 1 and Course 3
+    assert_eq!(data, 0); // Course 2 was deleted
 }

--- a/contracts/user_profile/src/test.rs
+++ b/contracts/user_profile/src/test.rs
@@ -1,19 +1,15 @@
 use soroban_sdk::{Address, Env, testutils::Address as _};
 use crate::{
     UserProfileContract,
-    functions::get_user_profile::{
-        user_profile_get_user_profile,
-        user_profile_get_user_profile_with_privacy
-    }
 };
 
 #[test]
 fn test_get_user_profile_function_exists() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, UserProfileContract);
+    let _contract_id = env.register(UserProfileContract, {});
     
     // Create a test user address
-    let user_address = Address::generate(&env);
+    let _user_address = Address::generate(&env);
     
     // This test verifies that the function exists and can be called
     // In a real implementation, you would need to save a profile first
@@ -27,11 +23,11 @@ fn test_get_user_profile_function_exists() {
 #[test]
 fn test_get_user_profile_with_privacy_function_exists() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, UserProfileContract);
+    let _contract_id = env.register(UserProfileContract, {});
     
     // Create test addresses
-    let user_address = Address::generate(&env);
-    let requester_address = Address::generate(&env);
+    let _user_address = Address::generate(&env);
+    let _requester_address = Address::generate(&env);
     
     // This test verifies that the function exists and can be called
     // In a real implementation, you would need to save a profile first


### PR DESCRIPTION
# 🔧 Fix: Resolve authorization errors and compiler warnings in Soroban contracts

## 📋 Summary
This PR fixes critical authorization errors in course registry tests and resolves various compiler warnings across the contract codebase. All tests now pass successfully (88/88).

## Closes #82 

## 🐛 Issues Fixed

### 1. Authorization Errors in Tests
- **Problem**: `Error(Auth, InvalidAction)` and `Error(Auth, InternalError)` in `test_list_categories_counts` and `test_list_categories_with_id_gaps`
- **Root Cause**: Incorrect authorization handling when calling contract functions directly within `env.as_contract()` context
- **Solution**: Replace direct `CourseRegistry::create_course()` calls with `client.create_course()` using proper `CourseRegistryClient`

### 2. Compiler Warnings
- **Problem**: Multiple unused import warnings across contracts
- **Fixed**: Removed unused imports in `course_access`, `course_registry`, and `user_profile` modules
- **Updated**: Deprecated `register_contract()` method to `register()` in tests

## 🔄 Changes Made

### `/contracts/course/course_access/src/functions/mod.rs`
```diff
- pub use has_access::*;  // ❌ Unused import
```

### `/contracts/course/course_registry/src/functions/add_goal.rs`
```diff
- use soroban_sdk::{symbol_short, Address, Env, String, Symbol, Vec};  // ❌ Vec unused
+ use soroban_sdk::{symbol_short, Address, Env, String, Symbol};       // ✅ Clean imports
```

### `/contracts/course/course_registry/src/functions/edit_goal.rs`
```diff
- use soroban_sdk::{testutils::{Address as _, Events}, Address, Env, String, Vec};  // ❌ Events, Vec unused  
+ use soroban_sdk::{testutils::Address as _, Address, Env, String};                  // ✅ Clean imports
```

### `/contracts/course/course_registry/src/test.rs`
**Major fix**: Authorization handling in test functions
```diff
❌ BEFORE (failing):
env.as_contract(&contract_id, || {
    env.mock_all_auths();  // Wrong: causes auth frame conflict
    CourseRegistry::create_course(...);  // Wrong: direct call without proper auth
});

✅ AFTER (working):
env.mock_all_auths();  // Correct: mock auth outside
let client = CourseRegistryClient::new(&env, &contract_id);
client.create_course(...);  // Correct: use client with proper auth handling
```

### `/contracts/user_profile/src/test.rs`
```diff
- let contract_id = env.register_contract(None, UserProfileContract);  // ❌ Deprecated
+ let contract_id = env.register(UserProfileContract, {});             // ✅ Current method
```

## ✅ Test Results
```
running 88 tests
...
test result: ok. 88 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## 🎯 Impact
- **Before**: 3 failing tests due to authorization errors
- **After**: All 88 tests passing
- **Warnings**: Reduced from multiple compiler warnings to clean build
- **Maintainability**: Improved code consistency and removed deprecated methods

## 🧪 Testing
- [x] All existing tests pass
- [x] No new test failures introduced  
- [x] Authorization flows work correctly
- [x] Compiler warnings resolved

## 📚 Technical Notes
The key insight was understanding Soroban's authorization model:
- `env.mock_all_auths()` must be called **outside** of `env.as_contract()` 
- Contract functions requiring auth should use `Client` pattern, not direct calls
- `env.as_contract()` should be reserved for direct storage operations only

## 🔗 Related Issues
- Fixes authorization failures in course registry tests
- Resolves compiler warnings for cleaner builds
- Improves overall code quality and maintainability

```wsl
josue1908@Josue:/mnt/c/Issues/skillcert_contracts$ cargo test
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /mnt/c/Issues/skillcert_contracts/contracts/user_profile/Cargo.toml
workspace: /mnt/c/Issues/skillcert_contracts/Cargo.toml
   Compiling proc-macro2 v1.0.95
   Compiling unicode-ident v1.0.18
   Compiling version_check v0.9.5
   Compiling typenum v1.18.0
   Compiling cfg-if v1.0.1
   Compiling serde v1.0.219
   Compiling serde_json v1.0.141
   Compiling libc v0.2.174
   Compiling autocfg v1.5.0
   Compiling subtle v2.6.1
   Compiling itoa v1.0.15
   Compiling memchr v2.7.5
   Compiling ryu v1.0.20
   Compiling const-oid v0.9.6
   Compiling semver v1.0.26
   Compiling fnv v1.0.7
   Compiling strsim v0.11.1
   Compiling ident_case v1.0.1
   Compiling generic-array v0.14.7
   Compiling zerocopy v0.8.26
   Compiling syn v1.0.109
   Compiling num-traits v0.2.19
   Compiling thiserror v1.0.69
   Compiling data-encoding v2.9.0
   Compiling paste v1.0.15
   Compiling rustc_version v0.4.1
   Compiling escape-bytes v0.1.1
   Compiling cpufeatures v0.2.17
   Compiling ahash v0.8.12
   Compiling quote v1.0.40
   Compiling hashbrown v0.15.4
   Compiling syn v2.0.104
   Compiling either v1.15.0
   Compiling base16ct v0.2.0
   Compiling getrandom v0.2.16
   Compiling equivalent v1.0.2
   Compiling rand_core v0.6.4
   Compiling indexmap v2.10.0
   Compiling itertools v0.10.5
   Compiling ff v0.13.1
   Compiling libm v0.2.15
   Compiling group v0.13.0
   Compiling num-integer v0.1.46
   Compiling once_cell v1.21.3
   Compiling base64 v0.13.1
   Compiling num-bigint v0.4.6
   Compiling wasmparser v0.116.1
   Compiling ppv-lite86 v0.2.21
   Compiling curve25519-dalek v4.1.3
   Compiling hashbrown v0.13.2
   Compiling rand_chacha v0.3.1
   Compiling ethnum v1.5.2
   Compiling indexmap-nostd v0.4.0
   Compiling rand v0.8.5
   Compiling static_assertions v1.1.0
   Compiling darling_core v0.20.11
   Compiling downcast-rs v1.2.1
   Compiling wasmparser-nostd v0.100.2
   Compiling block-buffer v0.10.4
   Compiling ark-std v0.4.0
   Compiling crypto-common v0.1.6
   Compiling smallvec v1.15.1
   Compiling wasmi_core v0.13.0
   Compiling prettyplease v0.2.35
   Compiling spin v0.9.8
   Compiling wasmi_arena v0.4.1
   Compiling digest v0.10.7
   Compiling keccak v0.1.5
   Compiling soroban-env-host v22.1.3
   Compiling hex-literal v0.4.1
   Compiling sha2 v0.10.9
   Compiling soroban-sdk v22.0.8
   Compiling serde_derive v1.0.219
   Compiling zeroize_derive v1.4.2
   Compiling thiserror-impl v1.0.69
   Compiling derive_arbitrary v1.3.2
   Compiling num-derive v0.4.2
   Compiling ark-serialize-derive v0.4.2
   Compiling darling_macro v0.20.11
   Compiling ark-ff-asm v0.4.2
   Compiling ark-ff-macros v0.4.2
   Compiling derivative v2.2.0
   Compiling curve25519-dalek-derive v0.1.1
   Compiling soroban-wasmi v0.31.1-soroban.20.0.1
   Compiling soroban-builtin-sdk-macros v22.1.3
   Compiling ctor v0.2.9
   Compiling bytes-lit v0.0.5
   Compiling arbitrary v1.3.2
   Compiling zeroize v1.8.1
   Compiling der v0.7.10
   Compiling sec1 v0.7.3
   Compiling crypto-bigint v0.5.5
   Compiling signature v2.2.0
   Compiling ark-serialize v0.4.2
   Compiling hmac v0.12.1
   Compiling rfc6979 v0.4.0
   Compiling ed25519 v2.2.3
   Compiling sha3 v0.10.8
   Compiling elliptic-curve v0.13.8
   Compiling ecdsa v0.16.9
   Compiling primeorder v0.13.6
   Compiling k256 v0.13.4
   Compiling p256 v0.13.2
   Compiling darling v0.20.11
   Compiling ed25519-dalek v2.2.0
   Compiling serde_with_macros v3.14.0
   Compiling ark-ff v0.4.2
   Compiling hex v0.4.3
   Compiling crate-git-revision v0.0.6
   Compiling stellar-strkey v0.0.9
   Compiling stellar-xdr v22.1.0
   Compiling soroban-env-common v22.1.3
   Compiling soroban-sdk-macros v22.0.8
   Compiling ark-poly v0.4.2
   Compiling ark-ec v0.4.2
   Compiling ark-bls12-381 v0.4.0
   Compiling serde_with v3.14.0
   Compiling soroban-spec v22.0.8
   Compiling soroban-spec-rust v22.0.8
   Compiling soroban-env-macros v22.1.3
   Compiling soroban-ledger-snapshot v22.0.8
   Compiling test_contract v0.0.0 (/mnt/c/Issues/skillcert_contracts/contracts/test_contract)
   Compiling course_access v0.0.0 (/mnt/c/Issues/skillcert_contracts/contracts/course/course_access)
   Compiling course_registry v0.0.0 (/mnt/c/Issues/skillcert_contracts/contracts/course/course_registry)
   Compiling user_management v0.1.0 (/mnt/c/Issues/skillcert_contracts/contracts/user_management)
   Compiling user_profile v0.1.0 (/mnt/c/Issues/skillcert_contracts/contracts/user_profile)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2m 12s
     Running unittests src/lib.rs (target/debug/deps/course_access-3c4cdd0d0a1885ac)

running 2 tests
test functions::list_course_access::test::test ... ok
test functions::list_user_courses::test::test ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.29s

     Running unittests src/lib.rs (target/debug/deps/course_registry-076b1993b3c6a164)

running 88 tests
test functions::add_module::test::test_add_module_invalid_course - should panic ... ok
test functions::add_goal::test::test_add_goal_course_not_found - should panic ... ok
test functions::archive_course::tests::test_archive_nonexistent_course - should panic ... ok
test functions::archive_course::tests::test_archive_course_by_non_creator - should panic ... ok
test functions::add_goal::test::test_add_goal_empty_content - should panic ... ok
test functions::add_goal::test::test_add_goal_unauthorized - should panic ... ok
test functions::archive_course::tests::test_archive_already_archived_course - should panic ... ok
test functions::create_course::test::test_cannot_create_courses_with_empty_title - should panic ... ok
test functions::add_module::test::test_add_module_success ... ok
test functions::add_module::test::test_course_registry_add_module_storage_key_format ... ok
test functions::create_course::test::test_cannot_create_courses_with_whitespace_only_title - should panic ... ok
test functions::create_course::test::test_cannot_create_courses_with_zero_price - should panic ... ok
test functions::create_course::test::test_add_course_success ... ok
test functions::add_module::test::test_course_registry_add_module_generates_unique_ids ... ok
test functions::archive_course::tests::test_archive_course_event_published ... ok
test functions::add_goal::test::test_add_goal_success ... ok
test functions::archive_course::tests::test_archive_course_success ... ok
test functions::create_course::test::test_cannot_create_courses_with_duplicate_title - should panic ... ok
test functions::add_goal::test::test_add_multiple_goals ... ok
test functions::create_course::test::test_create_course_empty_description ... ok
test functions::delete_course::tests::test_delete_course_not_found - should panic ... ok
test functions::create_course::test::test_generate_course_id ... ok
test functions::create_course::test::test_create_course_with_all_optional_fields ... ok
test functions::create_course::test::test_create_course_with_maximum_price ... ok
test functions::create_course::test::test_create_course_with_long_title ... ok
test functions::create_course::test::test_create_course_with_partial_optional_fields ... ok
test functions::create_course::test::test_create_course_with_special_characters ... ok
test functions::create_course::test::test_create_course_with_unicode_characters ... ok
test functions::create_course::test::test_duplicate_title_case_insensitive - should panic ... ok
test functions::edit_course::test::test_edit_course_not_found - should panic ... ok
test functions::create_course::test::test_add_course_success_multiple ... ok
test functions::delete_course::tests::test_delete_course_success ... ok
test functions::delete_course::tests::test_delete_course_with_modules ... ok
test functions::edit_goal::test::test_edit_goal_course_not_found - should panic ... ok
test functions::delete_course::tests::test_delete_course_unauthorized - should panic ... ok
test functions::delete_course::tests::test_impostor_cannot_delete_course - should panic ... ok
test functions::edit_course::test::test_edit_course_empty_title - should panic ... ok
test functions::delete_course::tests::test_delete_course_preserves_others ... ok
test functions::edit_course::test::test_edit_course_unauthorized - should panic ... ok
test functions::edit_course::test::test_edit_course_zero_price - should panic ... ok
test functions::edit_course::test::test_edit_course_success ... ok
test functions::create_course::test::test_create_multiple_courses_sequential_ids ... ok
test functions::edit_prerequisite::tests::test_edit_prerequisite_course_not_found - should panic ... ok
test functions::edit_course::test::test_edit_course_duplicate_title - should panic ... ok
test functions::edit_course::test::test_edit_course_partial_fields ... ok
test functions::edit_course::test::test_edit_course_same_title_no_change ... ok
test functions::edit_goal::test::test_edit_goal_empty_content - should panic ... ok
test functions::edit_goal::test::test_edit_goal_goal_not_found - should panic ... ok
test functions::edit_prerequisite::tests::test_edit_prerequisite_direct_circular_dependency - should panic ... ok
test functions::edit_goal::test::test_edit_goal_unauthorized - should panic ... ok
test functions::get_course::test::test_get_course_not_found - should panic ... ok
test functions::edit_prerequisite::tests::test_edit_prerequisite_invalid_prerequisite - should panic ... ok
test functions::get_courses_by_instructor::test::test_get_courses_by_instructor_no_courses ... ok
test functions::edit_goal::test::test_edit_goal_success ... ok
test functions::edit_prerequisite::tests::test_edit_prerequisite_authorization ... ok
test functions::get_course::test::test_get_archived_course - should panic ... ok
test functions::list_modules::test::test_add_module_invalid_course - should panic ... ok
test functions::get_course::test::test_get_course_success ... ok
test functions::remove_module::tests::test_remove_module_not_found - should panic ... ok
test functions::edit_prerequisite::tests::test_edit_prerequisite_empty_list ... ok
test functions::remove_module::tests::test_remove_module_with_empty_id - should panic ... ok
test functions::list_modules::test::test_course_registry_add_module_storage_key_format ... ok
test functions::is_course_creator::test::test_is_cource_creator_fail ... ok
test functions::is_course_creator::test::test_is_cource_creator_success ... ok
test functions::remove_prerequisite::test::test_remove_prerequisite_course_not_found - should panic ... ok
test test::test_get_course_not_found - should panic ... ok
test functions::edit_prerequisite::tests::test_edit_prerequisite_success ... ok
test functions::get_courses_by_instructor::test::test_get_courses_by_instructor_with_archived ... ok
test functions::remove_module::tests::test_remove_module_success ... ok
test functions::edit_prerequisite::tests::test_edit_prerequisite_indirect_circular_dependency - should panic ... ok
test test::test_get_courses_by_instructor_empty ... ok
test test::test_list_categories_empty ... ok
test functions::get_courses_by_instructor::test::test_get_courses_by_instructor ... ok
test test::test_get_course_success ... ok
test functions::edit_prerequisite::tests::test_edit_prerequisite_replace_existing ... ok
test functions::remove_prerequisite::test::test_remove_prerequisite_not_in_list - should panic ... ok
test test::test_get_courses_by_instructor_found ... ok
test test::test_get_prerequisites_by_course_id ... ok
test functions::remove_prerequisite::test::test_remove_prerequisite_unauthorized - should panic ... ok
test test::test_list_categories_ignores_none ... ok
test functions::remove_prerequisite::test::test_remove_prerequisite_success ... ok
test functions::edit_prerequisite::tests::test_edit_prerequisite_complex_chain ... ok
test test::test_remove_module_storage_isolation ... ok
test test::test_remove_module_success ... ok
test test::test_remove_multiple_different_modules ... ok
test functions::remove_prerequisite::test::test_remove_one_of_multiple_prerequisites ... ok
test test::test_list_categories_with_id_gaps ... ok
test test::test_list_categories_counts ... ok

test result: ok. 88 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 12.95s

     Running unittests src/lib.rs (target/debug/deps/test_contract-25a200b012ac2fc1)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/user_management-7480846b8ff4e191)

running 28 tests
test functions::list_all_registered_users::tests::test_matches_filter_role_match ... ok
test functions::list_all_registered_users::tests::test_matches_filter_role_no_match ... ok
test functions::list_all_registered_users::tests::test_matches_filter_no_filter ... ok
test functions::list_all_registered_users::tests::test_matches_filter_multiple_criteria ... ok
test functions::save_profile::test::test_save_profile_with_empty_email - should panic ... ok
test functions::save_profile::test::test_save_profile_with_empty_country - should panic ... ok
test functions::delete_user::tests::test_delete_nonexistent_user - should panic ... ok
test functions::save_profile::test::test_save_profile_with_empty_name - should panic ... ok
test functions::admin_management::tests::test_initialize_system ... ok
test functions::admin_management::tests::test_cannot_initialize_twice - should panic ... ok
test functions::admin_management::tests::test_non_super_admin_cannot_add_admin - should panic ... ok
test functions::delete_user::tests::test_delete_user_by_self_success ... ok
test functions::delete_user::tests::test_delete_already_inactive_user - should panic ... ok
test functions::save_profile::test::test_save_profile_success ... ok
test functions::admin_management::tests::test_add_remove_admin ... ok
test functions::delete_user::tests::test_delete_user_by_admin_success ... ok
test functions::save_profile::test::test_save_profile_without_optional_fields ... ok
test functions::delete_user::tests::test_delete_user_unauthorized - should panic ... ok
test test::test_list_all_users_empty_database ... ok
test test::test_save_profile_minimal_data ... ok
test test::test_save_profile_integration ... ok
test test::test_list_all_users_invalid_page_size ... ok
test test::test_list_all_users_country_filter ... ok
test test::test_list_all_users_basic_pagination ... ok
test test::test_list_all_users_non_admin_access ... ok
test test::test_list_all_users_multiple_filters ... ok
test test::test_list_all_users_role_filter ... ok
test test::test_list_all_users_status_filter ... ok

test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.59s

     Running unittests src/lib.rs (target/debug/deps/user_profile-2fc21e32f8e8bb77)

running 2 tests
test test::test_get_user_profile_function_exists ... ok
test test::test_get_user_profile_with_privacy_function_exists ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s

josue1908@Josue:/mnt/c/Issues/skillcert_contracts$
```
