### PR TITLE
chore(license): add MIT license headers to all .rs files

### DIFF
--- a/contracts/course/course_access/goals_view.rs
+++ b/contracts/course/course_access/goals_view.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 // src/course_registry/goals_view.rs
 
 use soroban_sdk::{contracttype, Address, Env, String, Symbol, Vec};

--- a/contracts/course/course_access/src/error.rs
+++ b/contracts/course/course_access/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{contracterror, panic_with_error, Env};
 
 #[contracterror]

--- a/contracts/course/course_access/src/functions/config.rs
+++ b/contracts/course/course_access/src/functions/config.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{KEY_COURSE_REG_ADDR, KEY_USER_MGMT_ADDR};
 use soroban_sdk::{Address, Env};
 

--- a/contracts/course/course_access/src/functions/grant_access.rs
+++ b/contracts/course/course_access/src/functions/grant_access.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{CourseAccess, DataKey, UserCourses, CourseUsers};
 use soroban_sdk::{Address, Env, String, Vec};
 use crate::error::{Error, handle_error};

--- a/contracts/course/course_access/src/functions/has_access.rs
+++ b/contracts/course/course_access/src/functions/has_access.rs
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
 

--- a/contracts/course/course_access/src/functions/list_course_access.rs
+++ b/contracts/course/course_access/src/functions/list_course_access.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{Env, String, Vec};
 
 use crate::schema::{CourseUsers, DataKey};

--- a/contracts/course/course_access/src/functions/list_user_courses.rs
+++ b/contracts/course/course_access/src/functions/list_user_courses.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{Address, Env, Vec};
 
 use crate::schema::{UserCourses, DataKey};

--- a/contracts/course/course_access/src/functions/mod.rs
+++ b/contracts/course/course_access/src/functions/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 pub mod grant_access;
 pub mod has_access;
 pub mod list_course_access;

--- a/contracts/course/course_access/src/functions/revoke_access.rs
+++ b/contracts/course/course_access/src/functions/revoke_access.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{Address, Env, String};
 use crate::schema::{DataKey, UserCourses, CourseUsers};
 

--- a/contracts/course/course_access/src/functions/revoke_all_access.rs
+++ b/contracts/course/course_access/src/functions/revoke_all_access.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{DataKey, KEY_COURSE_REG_ADDR, KEY_USER_MGMT_ADDR};
 use soroban_sdk::{symbol_short, Address, Env, IntoVal, String, Symbol, Vec};
 use crate::error::{Error, handle_error};

--- a/contracts/course/course_access/src/functions/save_profile.rs
+++ b/contracts/course/course_access/src/functions/save_profile.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{DataKey, UserProfile};
 use soroban_sdk::{Address, Env, String};
 use crate::error::{Error, handle_error};

--- a/contracts/course/course_access/src/functions/transfer_course_access.rs
+++ b/contracts/course/course_access/src/functions/transfer_course_access.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{CourseAccess, DataKey};
 use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 use crate::error::{Error, handle_error};

--- a/contracts/course/course_access/src/lib.rs
+++ b/contracts/course/course_access/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 #![no_std]
 
 mod functions;

--- a/contracts/course/course_access/src/schema.rs
+++ b/contracts/course/course_access/src/schema.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{contracttype, Address, String, Vec};
 
 /// Represents access permission for a user to a specific course

--- a/contracts/course/course_access/src/test.rs
+++ b/contracts/course/course_access/src/test.rs
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert

--- a/contracts/course/course_registry/src/error.rs
+++ b/contracts/course/course_registry/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{contracterror, panic_with_error, Env};
 
 #[contracterror]

--- a/contracts/course/course_registry/src/functions/add_goal.rs
+++ b/contracts/course/course_registry/src/functions/add_goal.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::functions::utils;
 use crate::schema::{Course, CourseGoal, DataKey};
 use crate::error::{Error, handle_error};

--- a/contracts/course/course_registry/src/functions/add_module.rs
+++ b/contracts/course/course_registry/src/functions/add_module.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 pub use crate::schema::{Course, CourseModule};
 use crate::error::{Error, handle_error};
 use soroban_sdk::{symbol_short, Env, String, Symbol, vec};

--- a/contracts/course/course_registry/src/functions/archive_course.rs
+++ b/contracts/course/course_registry/src/functions/archive_course.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 use crate::error::{Error, handle_error};
 

--- a/contracts/course/course_registry/src/functions/create_course.rs
+++ b/contracts/course/course_registry/src/functions/create_course.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{Course, CourseLevel};
 use soroban_sdk::{symbol_short, Address, Env, String, Symbol, Vec};
 use crate::error::{Error, handle_error};

--- a/contracts/course/course_registry/src/functions/create_course_category.rs
+++ b/contracts/course/course_registry/src/functions/create_course_category.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{DataKey, CourseCategory};
 use crate::error::{Error, handle_error};
 use soroban_sdk::{Address, Env, String, Vec};

--- a/contracts/course/course_registry/src/functions/create_prerequisite.rs
+++ b/contracts/course/course_registry/src/functions/create_prerequisite.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{Course, DataKey};
 use crate::error::{Error, handle_error};
 use soroban_sdk::{symbol_short, Address, Env, Map, String, Symbol, Vec};

--- a/contracts/course/course_registry/src/functions/delete_course.rs
+++ b/contracts/course/course_registry/src/functions/delete_course.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{Course, CourseModule};
 use crate::error::{Error, handle_error};
 use soroban_sdk::{

--- a/contracts/course/course_registry/src/functions/edit_course.rs
+++ b/contracts/course/course_registry/src/functions/edit_course.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{Course, EditCourseParams};
 use crate::error::{Error, handle_error};
 use soroban_sdk::{symbol_short, Address, Env, String, Symbol};

--- a/contracts/course/course_registry/src/functions/edit_goal.rs
+++ b/contracts/course/course_registry/src/functions/edit_goal.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{Course, CourseGoal, DataKey};
 use crate::error::{Error, handle_error};
 use super::is_course_creator::is_course_creator;

--- a/contracts/course/course_registry/src/functions/edit_prerequisite.rs
+++ b/contracts/course/course_registry/src/functions/edit_prerequisite.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{Course, DataKey};
 use crate::error::{Error, handle_error};
 use soroban_sdk::{symbol_short, Address, Env, Map, String, Symbol, Vec};

--- a/contracts/course/course_registry/src/functions/get_course.rs
+++ b/contracts/course/course_registry/src/functions/get_course.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{Env, String, Symbol};
 use crate::error::{Error, handle_error};
 

--- a/contracts/course/course_registry/src/functions/get_course_category.rs
+++ b/contracts/course/course_registry/src/functions/get_course_category.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
 
 use crate::schema::{CourseCategory, DataKey};
 use soroban_sdk::{Env};

--- a/contracts/course/course_registry/src/functions/get_courses_by_instructor.rs
+++ b/contracts/course/course_registry/src/functions/get_courses_by_instructor.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::Course;
 use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 use super::utils::u32_to_string;

--- a/contracts/course/course_registry/src/functions/get_prerequisites_by_course.rs
+++ b/contracts/course/course_registry/src/functions/get_prerequisites_by_course.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{Course, CourseId};
 use soroban_sdk::{symbol_short, Env, String, Vec};
 

--- a/contracts/course/course_registry/src/functions/is_course_creator.rs
+++ b/contracts/course/course_registry/src/functions/is_course_creator.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::Course;
 use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 const COURSE_KEY: Symbol = symbol_short!("course");

--- a/contracts/course/course_registry/src/functions/list_categories.rs
+++ b/contracts/course/course_registry/src/functions/list_categories.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{Category, Course};
 use soroban_sdk::{symbol_short, Env, Map, String, Symbol, Vec};
 use super::utils::u32_to_string;

--- a/contracts/course/course_registry/src/functions/list_courses_with_filters.rs
+++ b/contracts/course/course_registry/src/functions/list_courses_with_filters.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{Course, CourseFilters};
 use soroban_sdk::{symbol_short, Env, Symbol, Vec};
 

--- a/contracts/course/course_registry/src/functions/list_modules.rs
+++ b/contracts/course/course_registry/src/functions/list_modules.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::CourseModule;
 use crate::error::{Error, handle_error};
 use soroban_sdk::{Env, String, Symbol};

--- a/contracts/course/course_registry/src/functions/mod.rs
+++ b/contracts/course/course_registry/src/functions/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 pub mod add_goal;
 pub mod add_module;
 pub mod archive_course;

--- a/contracts/course/course_registry/src/functions/remove_goal.rs
+++ b/contracts/course/course_registry/src/functions/remove_goal.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{Course, CourseGoal, DataKey};
 use crate::error::{Error, handle_error};
 use soroban_sdk::{symbol_short, Address, Env, String, Symbol};

--- a/contracts/course/course_registry/src/functions/remove_module.rs
+++ b/contracts/course/course_registry/src/functions/remove_module.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::CourseModule;
 use crate::error::{Error, handle_error};
 use soroban_sdk::{symbol_short, Env, String};

--- a/contracts/course/course_registry/src/functions/remove_prerequisite.rs
+++ b/contracts/course/course_registry/src/functions/remove_prerequisite.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{Course, DataKey};
 use crate::error::{Error, handle_error};
 use soroban_sdk::{symbol_short, Address, Env, String, Symbol, Vec};

--- a/contracts/course/course_registry/src/functions/utils.rs
+++ b/contracts/course/course_registry/src/functions/utils.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 pub use crate::schema::{Course, CourseModule};
 use soroban_sdk::{Bytes, Env, String, Vec, vec};
 

--- a/contracts/course/course_registry/src/lib.rs
+++ b/contracts/course/course_registry/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 #![no_std]
 
 pub mod functions;

--- a/contracts/course/course_registry/src/schema.rs
+++ b/contracts/course/course_registry/src/schema.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{contracttype, Address, String, Vec};
 
 #[contracttype]

--- a/contracts/course/course_registry/src/test.rs
+++ b/contracts/course/course_registry/src/test.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::{schema::Category, CourseRegistry, CourseRegistryClient};
 use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, String, Vec};
 

--- a/contracts/test_contract/src/lib.rs
+++ b/contracts/test_contract/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 #![no_std]
 
 use soroban_sdk::{contract, contractimpl, Env, String};

--- a/contracts/user_management/src/error.rs
+++ b/contracts/user_management/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{contracterror, panic_with_error, Env};
 
 #[contracterror]

--- a/contracts/user_management/src/functions/admin_management.rs
+++ b/contracts/user_management/src/functions/admin_management.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{AdminConfig, DataKey};
 use crate::error::{Error, handle_error};
 use core::iter::Iterator;

--- a/contracts/user_management/src/functions/create_user_profile.rs
+++ b/contracts/user_management/src/functions/create_user_profile.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{DataKey, LightProfile, UserProfile, UserRole, UserStatus};
 use crate::error::{Error, handle_error};
 use core::iter::Iterator;

--- a/contracts/user_management/src/functions/delete_user.rs
+++ b/contracts/user_management/src/functions/delete_user.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{AdminConfig, DataKey, LightProfile, UserProfile, UserStatus};
 use crate::error::{Error, handle_error};
 use core::iter::Iterator;

--- a/contracts/user_management/src/functions/get_user_by_id.rs
+++ b/contracts/user_management/src/functions/get_user_by_id.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{DataKey, UserProfile};
 use crate::error::{Error, handle_error};
 use core::iter::Iterator;

--- a/contracts/user_management/src/functions/is_admin.rs
+++ b/contracts/user_management/src/functions/is_admin.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{Address, Env, Vec};
 use crate::schema::{AdminConfig, DataKey};
 

--- a/contracts/user_management/src/functions/list_all_registered_users.rs
+++ b/contracts/user_management/src/functions/list_all_registered_users.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{AdminConfig, DataKey, LightProfile, UserRole, UserStatus};
 use crate::error::{Error, handle_error};
 use core::iter::Iterator;

--- a/contracts/user_management/src/functions/list_users_with_access.rs.rs
+++ b/contracts/user_management/src/functions/list_users_with_access.rs.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 
 const EVT_ACCESS_LISTED: Symbol = symbol_short!("ac_listed");

--- a/contracts/user_management/src/functions/mod.rs
+++ b/contracts/user_management/src/functions/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 pub mod admin_management;
 pub mod create_user_profile;
 pub mod delete_user;

--- a/contracts/user_management/src/functions/save_profile.rs
+++ b/contracts/user_management/src/functions/save_profile.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::schema::{DataKey, LightProfile, UserProfile, UserRole, UserStatus};
 use crate::error::{Error, handle_error};
 use core::iter::Iterator;

--- a/contracts/user_management/src/lib.rs
+++ b/contracts/user_management/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 #![no_std]
 
 pub mod functions;

--- a/contracts/user_management/src/schema.rs
+++ b/contracts/user_management/src/schema.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{contracttype, Address, String, Vec};
 
 #[contracttype]

--- a/contracts/user_management/src/test.rs
+++ b/contracts/user_management/src/test.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use crate::{UserManagement, UserManagementClient};
 use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
 

--- a/contracts/user_profile/src/functions/get_user_profile.rs
+++ b/contracts/user_profile/src/functions/get_user_profile.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{Env, Address, Symbol};
 
 use crate::schema::UserProfile;

--- a/contracts/user_profile/src/functions/mod.rs
+++ b/contracts/user_profile/src/functions/mod.rs
@@ -1,1 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 pub mod get_user_profile;

--- a/contracts/user_profile/src/lib.rs
+++ b/contracts/user_profile/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 #![no_std]
 
 pub mod schema;

--- a/contracts/user_profile/src/schema.rs
+++ b/contracts/user_profile/src/schema.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{Address, String, contracttype};
 
 #[contracttype]

--- a/contracts/user_profile/src/test.rs
+++ b/contracts/user_profile/src/test.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 SkillCert
+
 use soroban_sdk::{Address, Env, testutils::Address as _};
 use crate::{
     UserProfileContract,


### PR DESCRIPTION
This PR adds the MIT license header to all `.rs` files in the project to comply with licensing requirements.

>>> Changes
- Added SPDX identifier and copyright notice to each `.rs` file
- Ensured consistency with root LICENSE file (MIT, 2025 SkillCert)

>>> Issue
Closes #124
