### PR TITLE
Standardize Function Order Across Contracts

### DIFF
--- a/contracts/course/course_registry/src/functions/create_course_category.rs
+++ b/contracts/course/course_registry/src/functions/create_course_category.rs
@@ -5,31 +5,6 @@ use crate::error::{handle_error, Error};
 use crate::schema::{CourseCategory, DataKey};
 use soroban_sdk::{Address, Env, String, Vec};
 
-/// Checks whether who is an admin using the same pattern as user_management contract.
-/// This assumes the course_registry contract has its own admin system or uses a similar pattern.
-fn is_admin(env: &Env, who: Address) -> bool {
-    // For now, we'll use a simple storage-based admin check
-    // In a production environment, you might want to integrate with the user_management contract
-    let admins: Option<Vec<Address>> = env.storage().persistent().get(&DataKey::Admins);
-    match admins {
-        Some(list) => list.iter().any(|a| a == who),
-        None => false,
-    }
-}
-
-/// Retrieves and increments a sequence used for category IDs.
-/// Storage key is DataKey::CategorySeq -> u128.
-fn next_category_id(env: &Env) -> u128 {
-    let mut seq: u128 = env
-        .storage()
-        .persistent()
-        .get(&DataKey::CategorySeq)
-        .unwrap_or(0u128);
-    seq = seq.saturating_add(1);
-    env.storage().persistent().set(&DataKey::CategorySeq, &seq);
-    seq
-}
-
 /// Creates a new course category (admin-only).
 ///
 /// Arguments:
@@ -76,4 +51,29 @@ pub fn course_registry_create_course_category(
 
     // Return the new ID
     id
+}
+
+/// Checks whether who is an admin using the same pattern as user_management contract.
+/// This assumes the course_registry contract has its own admin system or uses a similar pattern.
+fn is_admin(env: &Env, who: Address) -> bool {
+    // For now, we'll use a simple storage-based admin check
+    // In a production environment, you might want to integrate with the user_management contract
+    let admins: Option<Vec<Address>> = env.storage().persistent().get(&DataKey::Admins);
+    match admins {
+        Some(list) => list.iter().any(|a| a == who),
+        None => false,
+    }
+}
+
+/// Retrieves and increments a sequence used for category IDs.
+/// Storage key is DataKey::CategorySeq -> u128.
+fn next_category_id(env: &Env) -> u128 {
+    let mut seq: u128 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::CategorySeq)
+        .unwrap_or(0u128);
+    seq = seq.saturating_add(1);
+    env.storage().persistent().set(&DataKey::CategorySeq, &seq);
+    seq
 }

--- a/contracts/course/course_registry/src/functions/get_course.rs
+++ b/contracts/course/course_registry/src/functions/get_course.rs
@@ -6,6 +6,21 @@ use soroban_sdk::{Env, String, Symbol};
 
 use crate::schema::Course;
 
+/// Retrieves a course by its ID.
+///
+/// Arguments:
+/// - env: Soroban environment.
+/// - course_id: unique identifier of the course.
+///
+/// Returns:
+/// - Course: the course record associated with the given ID.
+///
+/// Errors:
+/// - Panics with `"Course not found"` if the course does not exist.
+/// - Returns `Error::CourseAlreadyArchived` if the course is archived.
+///
+/// Storage used (replace keys if your schema differs):
+/// - (("course", id),) -> Course    // course record by id
 pub fn course_registry_get_course(env: &Env, course_id: String) -> Course {
     // Create the storage key for the course
     let key = Symbol::new(env, "course");
@@ -27,23 +42,6 @@ pub fn course_registry_get_course(env: &Env, course_id: String) -> Course {
 mod test {
     use crate::{schema::Course, CourseRegistry, CourseRegistryClient};
     use soroban_sdk::{testutils::Address as _, Address, Env, String};
-
-    fn create_course<'a>(client: &CourseRegistryClient<'a>, creator: &Address) -> Course {
-        let title = String::from_str(&client.env, "title");
-        let description = String::from_str(&client.env, "description");
-        let price = 1000_u128;
-        client.create_course(
-            &creator,
-            &title,
-            &description,
-            &price,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-        )
-    }
 
     #[test]
     fn test_get_course_success() {
@@ -78,5 +76,22 @@ mod test {
         let course = create_course(&client, &creator);
         client.archive_course(&creator, &course.id);
         client.get_course(&course.id);
+    }
+
+    fn create_course<'a>(client: &CourseRegistryClient<'a>, creator: &Address) -> Course {
+        let title = String::from_str(&client.env, "title");
+        let description = String::from_str(&client.env, "description");
+        let price = 1000_u128;
+        client.create_course(
+            &creator,
+            &title,
+            &description,
+            &price,
+            &None,
+            &None,
+            &None,
+            &None,
+            &None,
+        )
     }
 }

--- a/contracts/user_management/src/functions/get_user_by_id.rs
+++ b/contracts/user_management/src/functions/get_user_by_id.rs
@@ -9,33 +9,6 @@ use soroban_sdk::{symbol_short, Address, Env, Symbol};
 // Optional: event symbol
 const EVT_GET_USER: Symbol = symbol_short!("get_user");
 
-fn is_admin(env: &Env, who: &Address) -> bool {
-    // Use the secure admin check from admin_management module
-    use crate::schema::AdminConfig;
-
-    // Check if system is initialized
-    let config: Option<AdminConfig> = env.storage().persistent().get(&DataKey::AdminConfig);
-    match config {
-        Some(cfg) if cfg.initialized => {
-            // Check if caller is super admin
-            if &cfg.super_admin == who {
-                return true;
-            }
-
-            // Check regular admin list
-            let admins: Option<soroban_sdk::Vec<Address>> =
-                env.storage()
-                    .persistent()
-                    .get::<DataKey, soroban_sdk::Vec<Address>>(&DataKey::Admins);
-            match admins {
-                Some(list) => list.iter().any(|a| a == *who),
-                None => false,
-            }
-        }
-        _ => false,
-    }
-}
-
 /// Get User by ID
 /// - Only the profile owner or an admin can access it.
 /// - Returns the full profile (assuming no sensitive data like passwords are stored in UserProfile).
@@ -61,4 +34,31 @@ pub fn get_user_by_id(env: Env, requester: Address, user_id: Address) -> UserPro
         .publish((EVT_GET_USER, &requester), user_id.clone());
 
     profile
+}
+
+fn is_admin(env: &Env, who: &Address) -> bool {
+    // Use the secure admin check from admin_management module
+    use crate::schema::AdminConfig;
+
+    // Check if system is initialized
+    let config: Option<AdminConfig> = env.storage().persistent().get(&DataKey::AdminConfig);
+    match config {
+        Some(cfg) if cfg.initialized => {
+            // Check if caller is super admin
+            if &cfg.super_admin == who {
+                return true;
+            }
+
+            // Check regular admin list
+            let admins: Option<soroban_sdk::Vec<Address>> =
+                env.storage()
+                    .persistent()
+                    .get::<DataKey, soroban_sdk::Vec<Address>>(&DataKey::Admins);
+            match admins {
+                Some(list) => list.iter().any(|a| a == *who),
+                None => false,
+            }
+        }
+        _ => false,
+    }
 }

--- a/contracts/user_management/src/functions/list_all_registered_users.rs
+++ b/contracts/user_management/src/functions/list_all_registered_users.rs
@@ -9,101 +9,6 @@ use soroban_sdk::{Address, Env, String, Vec};
 /// Security constants
 const MAX_PAGE_SIZE_ABSOLUTE: u32 = 1000;
 
-/// Checks whether the system is properly initialized
-fn is_system_initialized(env: &Env) -> bool {
-    if let Some(config) = env
-        .storage()
-        .persistent()
-        .get::<DataKey, AdminConfig>(&DataKey::AdminConfig)
-    {
-        config.initialized
-    } else {
-        false
-    }
-}
-
-/// Gets the admin configuration with defaults
-fn get_admin_config(env: &Env) -> AdminConfig {
-    env.storage()
-        .persistent()
-        .get::<DataKey, AdminConfig>(&DataKey::AdminConfig)
-        .unwrap_or_else(|| handle_error(&env, Error::SystemNotInitialized))
-}
-
-/// Checks whether the caller is an admin with enhanced security
-fn is_admin(env: &Env, who: &Address) -> bool {
-    // First check if system is initialized
-    if !is_system_initialized(env) {
-        return false;
-    }
-
-    let config = get_admin_config(env);
-
-    // Check if caller is the super admin
-    if &config.super_admin == who {
-        return true;
-    }
-
-    // Check if caller is in regular admin list
-    let admins: Option<Vec<Address>> = env
-        .storage()
-        .persistent()
-        .get::<DataKey, Vec<Address>>(&DataKey::Admins);
-    match admins {
-        Some(list) => list.iter().any(|a| a == *who),
-        None => false,
-    }
-}
-
-/// Checks if a profile matches the given filter criteria
-fn matches_filter(
-    profile: &LightProfile,
-    role_filter: &Option<UserRole>,
-    _country_filter: &Option<String>, // Deprecated but kept for API compatibility
-    status_filter: &Option<UserStatus>,
-) -> bool {
-    // Check role filter
-    if let Some(ref role) = role_filter {
-        if &profile.role != role {
-            return false;
-        }
-    }
-
-    // Note: Country filter was removed from the new schema as LightProfile
-    // no longer has a 'country' field. The parameter is kept for backward compatibility
-    // but the actual filtering is disabled.
-
-    // Check status filter
-    if let Some(ref status) = status_filter {
-        if &profile.status != status {
-            return false;
-        }
-    }
-
-    true
-}
-
-/// Validates and sanitizes input parameters
-fn validate_input(
-    page_size: u32,
-    _country_filter: &Option<String>, // Deprecated but kept for API compatibility
-    config: &AdminConfig,
-) -> Result<(), &'static str> {
-    // Validate page_size
-    let max_allowed = config.max_page_size.min(MAX_PAGE_SIZE_ABSOLUTE);
-    if page_size == 0 {
-        return Err("page_size must be greater than 0");
-    }
-    if page_size > max_allowed {
-        return Err("page_size exceeds maximum allowed limit");
-    }
-
-    // Country filter validation is no longer needed as it's deprecated
-    // but we keep the parameter for backward compatibility
-
-    Ok(())
-}
-
 /// Lists all registered users with pagination and filtering (admin-only).
 ///
 /// Arguments:
@@ -223,6 +128,101 @@ pub fn list_all_users(
     }
 
     result
+}
+
+/// Checks whether the system is properly initialized
+fn is_system_initialized(env: &Env) -> bool {
+    if let Some(config) = env
+        .storage()
+        .persistent()
+        .get::<DataKey, AdminConfig>(&DataKey::AdminConfig)
+    {
+        config.initialized
+    } else {
+        false
+    }
+}
+
+/// Gets the admin configuration with defaults
+fn get_admin_config(env: &Env) -> AdminConfig {
+    env.storage()
+        .persistent()
+        .get::<DataKey, AdminConfig>(&DataKey::AdminConfig)
+        .unwrap_or_else(|| handle_error(&env, Error::SystemNotInitialized))
+}
+
+/// Checks whether the caller is an admin with enhanced security
+fn is_admin(env: &Env, who: &Address) -> bool {
+    // First check if system is initialized
+    if !is_system_initialized(env) {
+        return false;
+    }
+
+    let config = get_admin_config(env);
+
+    // Check if caller is the super admin
+    if &config.super_admin == who {
+        return true;
+    }
+
+    // Check if caller is in regular admin list
+    let admins: Option<Vec<Address>> = env
+        .storage()
+        .persistent()
+        .get::<DataKey, Vec<Address>>(&DataKey::Admins);
+    match admins {
+        Some(list) => list.iter().any(|a| a == *who),
+        None => false,
+    }
+}
+
+/// Checks if a profile matches the given filter criteria
+fn matches_filter(
+    profile: &LightProfile,
+    role_filter: &Option<UserRole>,
+    _country_filter: &Option<String>, // Deprecated but kept for API compatibility
+    status_filter: &Option<UserStatus>,
+) -> bool {
+    // Check role filter
+    if let Some(ref role) = role_filter {
+        if &profile.role != role {
+            return false;
+        }
+    }
+
+    // Note: Country filter was removed from the new schema as LightProfile
+    // no longer has a 'country' field. The parameter is kept for backward compatibility
+    // but the actual filtering is disabled.
+
+    // Check status filter
+    if let Some(ref status) = status_filter {
+        if &profile.status != status {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Validates and sanitizes input parameters
+fn validate_input(
+    page_size: u32,
+    _country_filter: &Option<String>, // Deprecated but kept for API compatibility
+    config: &AdminConfig,
+) -> Result<(), &'static str> {
+    // Validate page_size
+    let max_allowed = config.max_page_size.min(MAX_PAGE_SIZE_ABSOLUTE);
+    if page_size == 0 {
+        return Err("page_size must be greater than 0");
+    }
+    if page_size > max_allowed {
+        return Err("page_size exceeds maximum allowed limit");
+    }
+
+    // Country filter validation is no longer needed as it's deprecated
+    // but we keep the parameter for backward compatibility
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/contracts/user_management/src/functions/save_profile.rs
+++ b/contracts/user_management/src/functions/save_profile.rs
@@ -15,17 +15,6 @@ const MAX_CATEGORY_LENGTH: usize = 100;
 const MAX_PASSWORD_LENGTH: usize = 128;
 const MIN_PASSWORD_LENGTH: usize = 8;
 
-/// Validates string content for security
-fn validate_string_content(_env: &Env, s: &String, max_len: usize) -> bool {
-    if s.len() > max_len as u32 {
-        return false;
-    }
-
-    // For no_std environment, we'll do basic length validation
-    // More sophisticated pattern matching can be added if needed
-    true
-}
-
 pub fn user_management_save_profile(
     env: Env,
     caller: Address,
@@ -202,6 +191,17 @@ pub fn user_management_save_profile(
     }
 
     user_profile
+}
+
+/// Validates string content for security
+fn validate_string_content(_env: &Env, s: &String, max_len: usize) -> bool {
+    if s.len() > max_len as u32 {
+        return false;
+    }
+
+    // For no_std environment, we'll do basic length validation
+    // More sophisticated pattern matching can be added if needed
+    true
 }
 
 /// Add user to the global users index


### PR DESCRIPTION
Reordered functions in contract files to follow consistent pattern: **public functions first, then private helpers**.

## Files Changed
- `user_management/src/functions/delete_user.rs`
- `user_management/src/functions/list_all_registered_users.rs` 
- `user_management/src/functions/get_user_by_id.rs`
- `user_management/src/functions/save_profile.rs`
- `course/course_registry/src/functions/create_course_category.rs`
- `course/course_registry/src/functions/get_course.rs`

**No functional changes:** pure refactoring for better readability

Closes #122 