### PR TITLE
Added reference to the license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,7 @@ stellar contract invoke \
 ```
 
 For more examples, check out the `scripts/invoke_examples.sh` file.
+
+## 📄 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
This PR added reference to the LICENSE file in the README, since the license already exists, there is no need creating a new one and so what we need is to reference it.

Closes #116 