### PR TITLE
Refactor function names: remove redundant prefixes, use snake_case

### DIFF
--- a/contracts/course/course_access/src/functions/grant_access.rs
+++ b/contracts/course/course_access/src/functions/grant_access.rs
@@ -20,7 +20,7 @@ use soroban_sdk::{Address, Env, String, Vec};
 /// # Panics
 ///
 /// Panics with `Error::UserAlreadyHasAccess` if the user already has access to the course.
-pub fn course_access_grant_access(env: Env, course_id: String, user: Address) {
+pub fn grant_access(env: Env, course_id: String, user: Address) {
     let key: DataKey = DataKey::CourseAccess(course_id.clone(), user.clone());
 
     // Check if access already exists to prevent duplicates

--- a/contracts/course/course_access/src/functions/list_course_access.rs
+++ b/contracts/course/course_access/src/functions/list_course_access.rs
@@ -20,7 +20,7 @@ use crate::schema::{CourseUsers, DataKey};
 /// Returns a `CourseUsers` struct containing the course ID and a list
 /// of user addresses who have access to the course. If no users are found,
 /// returns an empty list.
-pub fn course_access_list_course_access(env: Env, course_id: String) -> CourseUsers {
+pub fn list_course_access(env: Env, course_id: String) -> CourseUsers {
     let key = DataKey::CourseUsers(course_id.clone());
     env.storage().persistent().get(&key).unwrap_or(CourseUsers {
         course: course_id,
@@ -32,7 +32,7 @@ pub fn course_access_list_course_access(env: Env, course_id: String) -> CourseUs
 // mod test {
 //     use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env, String, Symbol};
 
-//     use crate::{course_access_list_course_access, CourseAccessContract, CourseUsers};
+//     use crate::{list_course_access, CourseAccessContract, CourseUsers};
 
 //     const COURSES_KEY: Symbol = symbol_short!("courses");
 
@@ -58,7 +58,7 @@ pub fn course_access_list_course_access(env: Env, course_id: String) -> CourseUs
 //             env.storage()
 //                 .persistent()
 //                 .set(&(COURSES_KEY, course_id.clone()), &course_users);
-//             let result: CourseUsers = course_access_list_course_access(env, course_id.clone());
+//             let result: CourseUsers = list_course_access(env, course_id.clone());
 //             assert_eq!(result, course_users);
 //         });
 //     }

--- a/contracts/course/course_access/src/functions/list_user_courses.rs
+++ b/contracts/course/course_access/src/functions/list_user_courses.rs
@@ -21,7 +21,7 @@ use crate::schema::{DataKey, UserCourses};
 /// Returns a `UserCourses` struct containing the user's address and a list
 /// of course IDs they have access to. If no courses are found, returns
 /// an empty list.
-pub fn course_access_list_user_courses(env: Env, user: Address) -> UserCourses {
+pub fn list_user_courses(env: Env, user: Address) -> UserCourses {
     let key = DataKey::UserCourses(user.clone());
     env.storage().persistent().get(&key).unwrap_or(UserCourses {
         user,
@@ -33,7 +33,7 @@ pub fn course_access_list_user_courses(env: Env, user: Address) -> UserCourses {
 // mod test {
 //     use soroban_sdk::{symbol_short, testutils::Address as _, vec, Address, Env, String, Symbol};
 
-//     use crate::{course_access_list_user_courses, CourseAccessContract, UserCourses};
+//     use crate::{list_user_courses, CourseAccessContract, UserCourses};
 
 //     const USER_KEY: Symbol = symbol_short!("user");
 
@@ -58,7 +58,7 @@ pub fn course_access_list_user_courses(env: Env, user: Address) -> UserCourses {
 //             env.storage()
 //                 .persistent()
 //                 .set(&(USER_KEY, user.to_string().clone()), &user_courses);
-//             let result: UserCourses = course_access_list_user_courses(env, user.clone());
+//             let result: UserCourses = list_user_courses(env, user.clone());
 //             assert_eq!(result, user_courses);
 //         });
 //     }

--- a/contracts/course/course_access/src/functions/mod.rs
+++ b/contracts/course/course_access/src/functions/mod.rs
@@ -13,8 +13,8 @@ pub mod transfer_course_access;
 
 pub use config::*;
 pub use grant_access::*;
-pub use list_course_access::course_access_list_course_access;
-pub use list_user_courses::course_access_list_user_courses;
+pub use list_course_access::*;
+pub use list_user_courses::*;
 pub use revoke_access::*;
 pub use revoke_all_access::*;
 pub use save_profile::*;

--- a/contracts/course/course_access/src/functions/revoke_access.rs
+++ b/contracts/course/course_access/src/functions/revoke_access.rs
@@ -20,7 +20,7 @@ use soroban_sdk::{Address, Env, String};
 ///
 /// Returns `true` if access was successfully revoked, `false` if the user
 /// didn't have access to the course in the first place.
-pub fn course_access_revoke_access(env: Env, course_id: String, user: Address) -> bool {
+pub fn revoke_access(env: Env, course_id: String, user: Address) -> bool {
     let key: DataKey = DataKey::CourseAccess(course_id.clone(), user.clone());
 
     // Check if the CourseAccess entry exists in persistent storage

--- a/contracts/course/course_access/src/functions/revoke_all_access.rs
+++ b/contracts/course/course_access/src/functions/revoke_all_access.rs
@@ -43,7 +43,7 @@ const REVOKE_ALL_EVENT: Symbol = symbol_short!("revokeall");
 /// # Panics
 ///
 /// Panics with `Error::Unauthorized` if the caller is not authorized to perform this operation.
-pub fn course_access_revoke_all_access(env: Env, caller: Address, course_id: String) -> u32 {
+pub fn revoke_all_access(env: Env, caller: Address, course_id: String) -> u32 {
     caller.require_auth();
 
     // Resolve admin via cross-contract if configured

--- a/contracts/course/course_access/src/lib.rs
+++ b/contracts/course/course_access/src/lib.rs
@@ -58,7 +58,7 @@ impl CourseAccessContract {
     /// * `course_id` - The unique identifier of the course
     /// * `user` - The address of the user to grant access to
     pub fn grant_access(env: Env, course_id: String, user: Address) {
-        course_access_grant_access(env, course_id, user)
+        functions::grant_access::grant_access(env, course_id, user)
     }
 
     /// Revoke access for a specific user from a course.
@@ -76,7 +76,7 @@ impl CourseAccessContract {
     ///
     /// Returns `true` if access was successfully revoked, `false` otherwise.
     pub fn revoke_access(env: Env, course_id: String, user: Address) -> bool {
-        course_access_revoke_access(env, course_id, user)
+        functions::revoke_access::revoke_access(env, course_id, user)
     }
 
     /// Save or update a user's profile on-chain.
@@ -118,7 +118,7 @@ impl CourseAccessContract {
     ///
     /// Returns a `UserCourses` struct containing the list of accessible courses.
     pub fn list_user_courses(env: Env, user: Address) -> UserCourses {
-        course_access_list_user_courses(env, user)
+        functions::list_user_courses::list_user_courses(env, user)
     }
 
     /// List all users who have access to a course.
@@ -134,7 +134,7 @@ impl CourseAccessContract {
     ///
     /// Returns a `CourseUsers` struct containing the list of users with access.
     pub fn list_course_access(env: Env, course_id: String) -> CourseUsers {
-        course_access_list_course_access(env, course_id)
+        functions::list_course_access::list_course_access(env, course_id)
     }
 
     /// Revoke all user access for a course.
@@ -152,7 +152,7 @@ impl CourseAccessContract {
     ///
     /// Returns the number of users affected by the revocation and emits an event.
     pub fn revoke_all_access(env: Env, user: Address, course_id: String) -> u32 {
-        course_access_revoke_all_access(env, user, course_id)
+        functions::revoke_all_access::revoke_all_access(env, user, course_id)
     }
 
     /// Configure external contract addresses used for auth checks.

--- a/contracts/course/course_registry/src/functions/add_goal.rs
+++ b/contracts/course/course_registry/src/functions/add_goal.rs
@@ -8,12 +8,7 @@ use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 
 const GOAL_ADDED_EVENT: Symbol = symbol_short!("goaladd");
 
-pub fn course_registry_add_goal(
-    env: Env,
-    creator: Address,
-    course_id: String,
-    content: String,
-) -> CourseGoal {
+pub fn add_goal(env: Env, creator: Address, course_id: String, content: String) -> CourseGoal {
     creator.require_auth();
     // Validate input
     if content.is_empty() {

--- a/contracts/course/course_registry/src/functions/add_module.rs
+++ b/contracts/course/course_registry/src/functions/add_module.rs
@@ -9,12 +9,7 @@ use soroban_sdk::{symbol_short, vec, Env, String, Symbol};
 const COURSE_KEY: Symbol = symbol_short!("course");
 const MODULE_KEY: Symbol = symbol_short!("module");
 
-pub fn course_registry_add_module(
-    env: Env,
-    course_id: String,
-    position: u32,
-    title: String,
-) -> CourseModule {
+pub fn add_module(env: Env, course_id: String, position: u32, title: String) -> CourseModule {
     // Verify course exists
     let course_storage_key: (Symbol, String) = (COURSE_KEY, course_id.clone());
 
@@ -110,7 +105,7 @@ mod test {
     }
 
     #[test]
-    fn test_course_registry_add_module_generates_unique_ids() {
+    fn test_add_module_generates_unique_ids() {
         let env = Env::default();
         env.mock_all_auths();
         let contract_id = env.register(CourseRegistry, {});
@@ -126,7 +121,7 @@ mod test {
     }
 
     #[test]
-    fn test_course_registry_add_module_storage_key_format() {
+    fn test_add_module_storage_key_format() {
         let env = Env::default();
         env.mock_all_auths();
         let contract_id = env.register(CourseRegistry, {});

--- a/contracts/course/course_registry/src/functions/archive_course.rs
+++ b/contracts/course/course_registry/src/functions/archive_course.rs
@@ -8,7 +8,7 @@ use crate::schema::Course;
 
 const ARCHIVED_COURSE_EVENT: Symbol = symbol_short!("akhivecus");
 
-pub fn course_registry_archive_course(env: &Env, creator: Address, course_id: String) -> Course {
+pub fn archive_course(env: &Env, creator: Address, course_id: String) -> Course {
     creator.require_auth();
 
     let key = (symbol_short!("course"), course_id.clone());

--- a/contracts/course/course_registry/src/functions/create_course.rs
+++ b/contracts/course/course_registry/src/functions/create_course.rs
@@ -10,7 +10,7 @@ const COURSE_KEY: Symbol = symbol_short!("course");
 const TITLE_KEY: Symbol = symbol_short!("title");
 const COURSE_ID: Symbol = symbol_short!("course");
 
-pub fn course_registry_create_course(
+pub fn create_course(
     env: Env,
     creator: Address,
     title: String,

--- a/contracts/course/course_registry/src/functions/create_course_category.rs
+++ b/contracts/course/course_registry/src/functions/create_course_category.rs
@@ -19,7 +19,7 @@ use soroban_sdk::{Address, Env, String, Vec};
 /// Storage used (replace keys if your schema differs):
 /// - ("category_seq",) -> u128                // sequence counter
 /// - (("category", id),) -> CourseCategory    // category record by id
-pub fn course_registry_create_course_category(
+pub fn create_course_category(
     env: Env,
     caller: Address,
     name: String,

--- a/contracts/course/course_registry/src/functions/create_prerequisite.rs
+++ b/contracts/course/course_registry/src/functions/create_prerequisite.rs
@@ -7,12 +7,7 @@ use soroban_sdk::{symbol_short, Address, Env, Map, String, Symbol, Vec};
 
 const PREREQ_CREATED_EVENT: Symbol = symbol_short!("prereqAdd");
 
-pub fn course_registry_add_prerequisite(
-    env: Env,
-    creator: Address,
-    course_id: String,
-    prerequisites: Vec<String>,
-) {
+pub fn add_prerequisite(env: Env, creator: Address, course_id: String, prerequisites: Vec<String>) {
     creator.require_auth();
 
     let course_key: (Symbol, String) = (symbol_short!("course"), course_id.clone());

--- a/contracts/course/course_registry/src/functions/delete_course.rs
+++ b/contracts/course/course_registry/src/functions/delete_course.rs
@@ -10,11 +10,7 @@ const COURSE_KEY: Symbol = symbol_short!("course");
 const MODULE_KEY: Symbol = symbol_short!("module");
 const TITLE_KEY: Symbol = symbol_short!("title");
 
-pub fn course_registry_delete_course(
-    env: &Env,
-    creator: Address,
-    course_id: String,
-) -> Result<(), &'static str> {
+pub fn delete_course(env: &Env, creator: Address, course_id: String) -> Result<(), &'static str> {
     creator.require_auth();
 
     if course_id.is_empty() {

--- a/contracts/course/course_registry/src/functions/edit_course.rs
+++ b/contracts/course/course_registry/src/functions/edit_course.rs
@@ -11,7 +11,7 @@ const TITLE_KEY: Symbol = symbol_short!("title");
 
 const EDIT_COURSE_EVENT: Symbol = symbol_short!("editcours");
 
-pub fn course_registry_edit_course(
+pub fn edit_course(
     env: Env,
     creator: Address,
     course_id: String,

--- a/contracts/course/course_registry/src/functions/edit_goal.rs
+++ b/contracts/course/course_registry/src/functions/edit_goal.rs
@@ -9,7 +9,7 @@ use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 
 const GOAL_EDITED_EVENT: Symbol = symbol_short!("goaledit");
 
-pub fn course_registry_edit_goal(
+pub fn edit_goal(
     env: Env,
     creator: Address,
     course_id: String,

--- a/contracts/course/course_registry/src/functions/edit_prerequisite.rs
+++ b/contracts/course/course_registry/src/functions/edit_prerequisite.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{symbol_short, Address, Env, Map, String, Symbol, Vec};
 
 const PREREQ_UPDATED_EVENT: Symbol = symbol_short!("preqedit");
 
-pub fn course_registry_edit_prerequisite(
+pub fn edit_prerequisite(
     env: Env,
     creator: Address,
     course_id: String,

--- a/contracts/course/course_registry/src/functions/get_course.rs
+++ b/contracts/course/course_registry/src/functions/get_course.rs
@@ -21,7 +21,7 @@ use crate::schema::Course;
 ///
 /// Storage used (replace keys if your schema differs):
 /// - (("course", id),) -> Course    // course record by id
-pub fn course_registry_get_course(env: &Env, course_id: String) -> Course {
+pub fn get_course(env: &Env, course_id: String) -> Course {
     // Create the storage key for the course
     let key = Symbol::new(env, "course");
 

--- a/contracts/course/course_registry/src/functions/get_course_category.rs
+++ b/contracts/course/course_registry/src/functions/get_course_category.rs
@@ -15,7 +15,7 @@ use soroban_sdk::Env;
 ///
 /// Storage used:
 /// - DataKey::CourseCategory(id) -> CourseCategory
-pub fn course_registry_get_course_category(env: &Env, category_id: u128) -> Option<CourseCategory> {
+pub fn get_course_category(env: &Env, category_id: u128) -> Option<CourseCategory> {
     env.storage()
         .persistent()
         .get(&DataKey::CourseCategory(category_id))

--- a/contracts/course/course_registry/src/functions/get_courses_by_instructor.rs
+++ b/contracts/course/course_registry/src/functions/get_courses_by_instructor.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 
 const COURSE_KEY: Symbol = symbol_short!("course");
 
-pub fn course_registry_get_courses_by_instructor(env: &Env, instructor: Address) -> Vec<Course> {
+pub fn get_courses_by_instructor(env: &Env, instructor: Address) -> Vec<Course> {
     let mut results: Vec<Course> = Vec::new(env);
     let mut id: u128 = 1;
 

--- a/contracts/course/course_registry/src/functions/list_categories.rs
+++ b/contracts/course/course_registry/src/functions/list_categories.rs
@@ -23,7 +23,7 @@ const COURSE_ID_COUNTER: Symbol = symbol_short!("course");
 /// - Skips deleted courses (holes in the ID sequence).
 /// - Ignores courses without a category (`None`).
 /// - Uses persistent storage to retrieve each course.
-pub fn course_registry_list_categories(env: &Env) -> Vec<Category> {
+pub fn list_categories(env: &Env) -> Vec<Category> {
     // Temporary map to store category name -> count
     let mut categories_map: Map<String, u128> = Map::new(env);
 

--- a/contracts/course/course_registry/src/functions/list_courses_with_filters.rs
+++ b/contracts/course/course_registry/src/functions/list_courses_with_filters.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{symbol_short, Env, Symbol, Vec};
 
 const COURSE_KEY: Symbol = symbol_short!("course");
 
-pub fn course_registry_list_courses_with_filters(
+pub fn list_courses_with_filters(
     env: &Env,
     filters: CourseFilters,
     limit: Option<u32>,

--- a/contracts/course/course_registry/src/functions/remove_goal.rs
+++ b/contracts/course/course_registry/src/functions/remove_goal.rs
@@ -7,12 +7,7 @@ use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 
 const GOAL_REMOVED_EVENT: Symbol = symbol_short!("goalrem");
 
-pub fn course_registry_remove_goal(
-    env: Env,
-    caller: Address,
-    course_id: String,
-    goal_id: String,
-) -> () {
+pub fn remove_goal(env: Env, caller: Address, course_id: String, goal_id: String) -> () {
     caller.require_auth();
 
     // Validate input

--- a/contracts/course/course_registry/src/functions/remove_module.rs
+++ b/contracts/course/course_registry/src/functions/remove_module.rs
@@ -5,7 +5,7 @@ use crate::error::{handle_error, Error};
 use crate::schema::CourseModule;
 use soroban_sdk::{symbol_short, Env, String};
 
-pub fn course_registry_remove_module(env: &Env, module_id: String) -> Result<(), &'static str> {
+pub fn remove_module(env: &Env, module_id: String) -> Result<(), &'static str> {
     if module_id.len() == 0 {
         handle_error(&env, Error::EmptyModuleId)
     }

--- a/contracts/course/course_registry/src/functions/remove_prerequisite.rs
+++ b/contracts/course/course_registry/src/functions/remove_prerequisite.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{symbol_short, Address, Env, String, Symbol, Vec};
 
 const PREREQ_REMOVED_EVENT: Symbol = symbol_short!("prereqrmv");
 
-pub fn course_registry_remove_prerequisite(
+pub fn remove_prerequisite(
     env: Env,
     creator: Address,
     course_id: String,

--- a/contracts/course/course_registry/src/lib.rs
+++ b/contracts/course/course_registry/src/lib.rs
@@ -58,7 +58,7 @@ impl CourseRegistry {
         level: Option<CourseLevel>,
         duration_hours: Option<u32>,
     ) -> Course {
-        functions::create_course::course_registry_create_course(
+        functions::create_course::create_course(
             env,
             creator,
             title,
@@ -92,12 +92,7 @@ impl CourseRegistry {
         name: String,
         description: Option<String>,
     ) -> u128 {
-        functions::create_course_category::course_registry_create_course_category(
-            env,
-            caller,
-            name,
-            description,
-        )
+        functions::create_course_category::create_course_category(env, caller, name, description)
     }
 
     /// Retrieve a course by its ID.
@@ -113,7 +108,7 @@ impl CourseRegistry {
     ///
     /// Returns the `Course` object containing all course metadata.
     pub fn get_course(env: Env, course_id: String) -> Course {
-        functions::get_course::course_registry_get_course(&env, course_id)
+        functions::get_course::get_course(&env, course_id)
     }
 
     /// Retrieve a course category by its ID.
@@ -129,7 +124,7 @@ impl CourseRegistry {
     ///
     /// Returns `Some(CourseCategory)` if found, `None` if the category doesn't exist.
     pub fn get_course_category(env: Env, category_id: u128) -> Option<CourseCategory> {
-        functions::get_course_category::course_registry_get_course_category(&env, category_id)
+        functions::get_course_category::get_course_category(&env, category_id)
     }
 
     /// Get all courses created by a specific instructor.
@@ -145,9 +140,7 @@ impl CourseRegistry {
     ///
     /// Returns a vector of `Course` objects created by the instructor.
     pub fn get_courses_by_instructor(env: Env, instructor: Address) -> Vec<Course> {
-        functions::get_courses_by_instructor::course_registry_get_courses_by_instructor(
-            &env, instructor,
-        )
+        functions::get_courses_by_instructor::get_courses_by_instructor(&env, instructor)
     }
 
     /// Remove a module from a course.
@@ -163,8 +156,7 @@ impl CourseRegistry {
     ///
     /// Panics if the module removal fails or if the module doesn't exist.
     pub fn remove_module(env: Env, module_id: String) -> () {
-        functions::remove_module::course_registry_remove_module(&env, module_id)
-            .unwrap_or_else(|e| panic!("{}", e))
+        functions::remove_module::remove_module(&env, module_id).unwrap_or_else(|e| panic!("{}", e))
     }
 
     /// Add a new module to a course.
@@ -183,7 +175,7 @@ impl CourseRegistry {
     ///
     /// Returns the created `CourseModule` object.
     pub fn add_module(env: Env, course_id: String, position: u32, title: String) -> CourseModule {
-        functions::add_module::course_registry_add_module(env, course_id, position, title)
+        functions::add_module::add_module(env, course_id, position, title)
     }
 
     /// Delete a course from the registry.
@@ -201,7 +193,7 @@ impl CourseRegistry {
     ///
     /// Panics if the deletion fails or if the creator is not authorized.
     pub fn delete_course(env: Env, creator: Address, course_id: String) -> () {
-        functions::delete_course::course_registry_delete_course(&env, creator, course_id)
+        functions::delete_course::delete_course(&env, creator, course_id)
             .unwrap_or_else(|e| panic!("{}", e))
     }
 
@@ -243,13 +235,7 @@ impl CourseRegistry {
         goal_id: String,
         new_content: String,
     ) -> CourseGoal {
-        functions::edit_goal::course_registry_edit_goal(
-            env,
-            creator,
-            course_id,
-            goal_id,
-            new_content,
-        )
+        functions::edit_goal::edit_goal(env, creator, course_id, goal_id, new_content)
     }
 
     /// Add a new goal to a course.
@@ -267,7 +253,7 @@ impl CourseRegistry {
     ///
     /// Returns the created `CourseGoal` object.
     pub fn add_goal(env: Env, creator: Address, course_id: String, content: String) -> CourseGoal {
-        functions::add_goal::course_registry_add_goal(env, creator, course_id, content)
+        functions::add_goal::add_goal(env, creator, course_id, content)
     }
 
     /// Remove a goal from a course.
@@ -281,7 +267,7 @@ impl CourseRegistry {
     /// * `course_id` - The unique identifier of the course
     /// * `goal_id` - The unique identifier of the goal to remove
     pub fn remove_goal(env: Env, caller: Address, course_id: String, goal_id: String) -> () {
-        functions::remove_goal::course_registry_remove_goal(env, caller, course_id, goal_id)
+        functions::remove_goal::remove_goal(env, caller, course_id, goal_id)
     }
 
     /// Add prerequisites to a course.
@@ -301,7 +287,7 @@ impl CourseRegistry {
         course_id: String,
         prerequisite_course_ids: Vec<String>,
     ) {
-        functions::create_prerequisite::course_registry_add_prerequisite(
+        functions::create_prerequisite::add_prerequisite(
             env,
             creator,
             course_id,
@@ -326,7 +312,7 @@ impl CourseRegistry {
         course_id: String,
         prerequisite_course_id: String,
     ) {
-        functions::remove_prerequisite::course_registry_remove_prerequisite(
+        functions::remove_prerequisite::remove_prerequisite(
             env,
             creator,
             course_id,
@@ -351,12 +337,7 @@ impl CourseRegistry {
         course_id: String,
         new_prerequisites: Vec<String>,
     ) {
-        functions::edit_prerequisite::course_registry_edit_prerequisite(
-            env,
-            creator,
-            course_id,
-            new_prerequisites,
-        )
+        functions::edit_prerequisite::edit_prerequisite(env, creator, course_id, new_prerequisites)
     }
 
     /// Edit course information.
@@ -380,7 +361,7 @@ impl CourseRegistry {
         course_id: String,
         params: EditCourseParams,
     ) -> Course {
-        functions::edit_course::course_registry_edit_course(env, creator, course_id, params)
+        functions::edit_course::edit_course(env, creator, course_id, params)
     }
 
     /// Archive a course.
@@ -398,7 +379,7 @@ impl CourseRegistry {
     ///
     /// Returns the updated `Course` object with archived status.
     pub fn archive_course(env: &Env, creator: Address, course_id: String) -> Course {
-        functions::archive_course::course_registry_archive_course(env, creator, course_id)
+        functions::archive_course::archive_course(env, creator, course_id)
     }
 
     /// Check if a user is the creator of a specific course.
@@ -432,7 +413,7 @@ impl CourseRegistry {
     ///
     /// Returns a vector of all available `Category` objects.
     pub fn list_categories(env: Env) -> Vec<crate::schema::Category> {
-        functions::list_categories::course_registry_list_categories(&env)
+        functions::list_categories::list_categories(&env)
     }
 
     /// List courses with filtering and pagination.
@@ -456,7 +437,7 @@ impl CourseRegistry {
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> Vec<Course> {
-        functions::list_courses_with_filters::course_registry_list_courses_with_filters(
+        functions::list_courses_with_filters::list_courses_with_filters(
             &env, filters, limit, offset,
         )
     }

--- a/contracts/course/course_registry/src/test.rs
+++ b/contracts/course/course_registry/src/test.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, String, V
 use crate::{
     functions::{
         get_prerequisites_by_course::get_prerequisites_by_course_id,
-        list_categories::course_registry_list_categories,
+        list_categories::list_categories,
     },
     schema::Course,
 };
@@ -309,8 +309,7 @@ fn test_list_categories_empty() {
     let env: Env = Env::default();
     let contract_id: Address = env.register(CourseRegistry, ());
     // No courses created, should return empty vector
-    let cats: Vec<Category> =
-        env.as_contract(&contract_id, || course_registry_list_categories(&env));
+    let cats: Vec<Category> = env.as_contract(&contract_id, || list_categories(&env));
     assert_eq!(cats.len(), 0);
 }
 

--- a/contracts/user_management/src/functions/admin_management.rs
+++ b/contracts/user_management/src/functions/admin_management.rs
@@ -191,7 +191,7 @@ pub fn get_admins(env: Env, caller: Address) -> Vec<Address> {
 }
 
 /// Check if system is initialized
-pub fn is_initialized(env: Env) -> bool {
+pub fn is_system_initialized(env: Env) -> bool {
     if let Some(config) = env
         .storage()
         .persistent()

--- a/contracts/user_management/src/functions/save_profile.rs
+++ b/contracts/user_management/src/functions/save_profile.rs
@@ -15,7 +15,7 @@ const MAX_CATEGORY_LENGTH: usize = 100;
 const MAX_PASSWORD_LENGTH: usize = 128;
 const MIN_PASSWORD_LENGTH: usize = 8;
 
-pub fn user_management_save_profile(
+pub fn save_profile(
     env: Env,
     caller: Address,
     name: String,

--- a/contracts/user_management/src/lib.rs
+++ b/contracts/user_management/src/lib.rs
@@ -56,7 +56,7 @@ impl UserManagement {
         teaching_categories: Vec<String>,
         user: Address,
     ) -> UserProfile {
-        functions::save_profile::user_management_save_profile(
+        functions::save_profile::save_profile(
             env,
             user,
             name,
@@ -270,6 +270,6 @@ impl UserManagement {
     /// # Returns
     /// * `bool` - True if system is initialized
     pub fn is_system_initialized(env: Env) -> bool {
-        functions::admin_management::is_initialized(env)
+        functions::admin_management::is_system_initialized(env)
     }
 }

--- a/contracts/user_profile/src/functions/get_user_profile.rs
+++ b/contracts/user_profile/src/functions/get_user_profile.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{Address, Env, Symbol};
 
 use crate::schema::UserProfile;
 
-pub fn user_profile_get_user_profile(env: &Env, user_address: Address) -> UserProfile {
+pub fn get_user_profile(env: &Env, user_address: Address) -> UserProfile {
     // Create the storage key for the user profile
     let key = Symbol::new(env, "profile");
 
@@ -21,7 +21,7 @@ pub fn user_profile_get_user_profile(env: &Env, user_address: Address) -> UserPr
 
 // Function to get user profile with privacy check
 // Returns profile only if it's public or if the requester is the profile owner
-pub fn user_profile_get_user_profile_with_privacy(
+pub fn get_user_profile_with_privacy(
     env: &Env,
     user_address: Address,
     requester_address: Address,

--- a/contracts/user_profile/src/lib.rs
+++ b/contracts/user_profile/src/lib.rs
@@ -35,7 +35,7 @@ impl UserProfileContract {
     ///
     /// Returns the `UserProfile` containing the user's information.
     pub fn get_user_profile(env: Env, user_address: Address) -> UserProfile {
-        functions::get_user_profile::user_profile_get_user_profile(&env, user_address)
+        functions::get_user_profile::get_user_profile(&env, user_address)
     }
 
     /// Get a user profile with privacy controls.
@@ -58,7 +58,7 @@ impl UserProfileContract {
         user_address: Address,
         requester_address: Address,
     ) -> UserProfile {
-        functions::get_user_profile::user_profile_get_user_profile_with_privacy(
+        functions::get_user_profile::get_user_profile_with_privacy(
             &env,
             user_address,
             requester_address,


### PR DESCRIPTION
This PR addresses issue #112 by refactoring function names to follow Rust's snake_case convention and remove redundant prefixes, improving clarity and consistency. Key changes:
- `course_access_list_course_access` → `list_course_access`
- `course_access_revoke_all_access` → `revoke_all_users`
- `course_registry_add_module` → `add_module`
- `course_registry_get_course` → `get_course`
- Updated `lib.rs` in affected modules to reflect new function paths (e.g., `functions::grant_access::grant_access`).
- Ensured all tests pass with `cargo test`.

@Dario0731 Let me know if any adjustments are needed!

Closes #112