### PR TITLE
docs: add docstrings to list_user_courses.rs

### DIFF
--- a/contracts/course/course_access/src/functions/list_user_courses.rs
+++ b/contracts/course/course_access/src/functions/list_user_courses.rs
@@ -5,7 +5,21 @@ use soroban_sdk::{Address, Env, Vec};
 
 use crate::schema::{DataKey, UserCourses};
 
-
+/// Retrieves the list of courses associated with a specific user.
+///
+/// This function queries the persistent storage to fetch all courses 
+/// that the specified user has access to. If no courses are found for
+/// the user, it returns an empty `UserCourses` struct.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment context for accessing storage and other SDK features.
+/// * `user` - The blockchain address of the user whose courses are being retrieved.
+///
+/// # Returns
+///
+/// * `UserCourses` - A struct containing the user's address and a vector of their course IDs.
+///   If the user has no courses, returns a `UserCourses` with an empty courses vector.
 pub fn list_user_courses(env: Env, user: Address) -> UserCourses {
     let key: DataKey = DataKey::UserCourses(user.clone());
     let res: UserCourses = env.storage().persistent().get(&key).unwrap_or(UserCourses {
@@ -23,6 +37,11 @@ mod test {
     use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
     use super::list_user_courses;
 
+    /// Tests the `list_user_courses` function to verify correct retrieval of user courses.
+    ///
+    /// This test sets up a mock environment with a registered contract and user,
+    /// creates course data, stores it in persistent storage, and verifies that
+    /// `list_user_courses` correctly retrieves the stored data.
     #[test]
     fn test_list_user_courses() {
         let env: Env = Env::default();


### PR DESCRIPTION
## Summary

This PR adds comprehensive docstrings to all functions in `contracts/course/course_access/src/functions/list_user_courses.rs`, following the project's documentation template as specified in issue #203.

## Changes

### `list_user_courses` function
Added documentation including:
- **Brief description**: Explains that the function retrieves the list of courses associated with a specific user
- **Arguments**:
  - `env` - The Soroban environment context
  - `user` - The blockchain address of the user
- **Returns**: Description of the `UserCourses` struct returned

### `test_list_user_courses` test function
Added documentation describing the test's purpose and what it verifies.

## Documentation Format

All docstrings follow the required template:
```rust
/// Brief description: explains what the function does.
///
/// # Arguments
///
/// * `param1` - Explanation of the first parameter.
/// * `param2` - Explanation of the second parameter.
///
/// # Returns
///
/// * `Result<T, E>` - What the function returns.
```

## Checklist

- [x] Docstrings added to all functions
- [x] Follows project documentation template
- [x] Includes parameter descriptions
- [x] Includes return value description

Closes #203